### PR TITLE
Use GitHub hosted runner

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,10 +1,20 @@
 name: hook github action in dataware-tools/web-deployment
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - master
+      - main
 
 jobs:
   hook:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Repository Dispatch


### PR DESCRIPTION
## What?
Self-hosted runner を使わない

## Why?
self-hosted runner 上でビルドするとネットワークエラーが多発するため

## See also [Optional]
https://github.com/dataware-tools/web-deployment/pull/8