### PR TITLE
disable style of RecordList in hovering on cell

### DIFF
--- a/src/components/organisms/RecordList.tsx
+++ b/src/components/organisms/RecordList.tsx
@@ -15,6 +15,7 @@ const Component = ({ records, onClickRow }: Props): JSX.Element => {
       columns={[{ field: "record_id" }, { field: "description" }]}
       onClickRow={onClickRow}
       stickyHeader
+      disableHoverCell
     />
   );
 };


### PR DESCRIPTION
## What?
- disable style of RecordList in hovering on cell

## Why?
- RecordList has action only for in clicking row, not in clicking each cell.
