### PR TITLE
Hide metadata for record

### DIFF
--- a/src/components/organisms/FileListItem.tsx
+++ b/src/components/organisms/FileListItem.tsx
@@ -35,7 +35,7 @@ const Component = ({
   onDelete,
   onDownload,
 }: Props): JSX.Element | null => {
-  if (file.path == null) return null;
+  if (file.path == null || file.path === "" || file.path === "/") return null;
 
   return (
     <ListItem


### PR DESCRIPTION
## What?
- Hide metadata for record

## Why?
- Metadata existing only for show record should not be shown in file list