### PR TITLE
change modalTitle fonts

### DIFF
--- a/src/components/organisms/DisplayConfigEditModal.tsx
+++ b/src/components/organisms/DisplayConfigEditModal.tsx
@@ -26,6 +26,7 @@ import {
   DialogCloseButton,
   SquareIconButton,
   TextCenteringSpan,
+  // NoticeableLetters,
 } from "@dataware-tools/app-common";
 import { produce } from "immer";
 import { mutate } from "swr";
@@ -204,7 +205,10 @@ const Container = ({
       <DialogWrapper>
         <DialogCloseButton onClick={onClose} />
         <DialogTitle>
+          {/* //TODO:Fix typeError */}
+          {/* <NoticeableLetters> */}
           <TextCenteringSpan>{title[configName] + " "}</TextCenteringSpan>
+          {/* </NoticeableLetters> */}
           {getConfigRes ? (
             <SquareIconButton onClick={onAdd} icon={<AddCircleIcon />} />
           ) : null}

--- a/src/components/organisms/ExportMetadataModal.tsx
+++ b/src/components/organisms/ExportMetadataModal.tsx
@@ -15,6 +15,7 @@ import {
   DialogCloseButton,
   DialogWrapper,
   DialogMain,
+  NoticeableLetters,
 } from "@dataware-tools/app-common";
 import { useAuth0 } from "@auth0/auth0-react";
 
@@ -74,7 +75,9 @@ const Component = ({
     <Dialog open={open} maxWidth="xl" onClose={onClose}>
       <DialogWrapper>
         <DialogCloseButton onClick={onClose} />
-        <DialogTitle>{`Export metadata in ${databaseId}`}</DialogTitle>
+        <DialogTitle>
+          <NoticeableLetters>{`Export metadata in ${databaseId}`}</NoticeableLetters>
+        </DialogTitle>
         <DialogContainer height="auto">
           <DialogBody>
             <DialogMain>

--- a/src/components/organisms/InputConfigEditModal.tsx
+++ b/src/components/organisms/InputConfigEditModal.tsx
@@ -25,6 +25,7 @@ import {
   TextCenteringSpan,
   DialogWrapper,
   DialogMain,
+  // NoticeableLetters,
 } from "@dataware-tools/app-common";
 import {
   InputConfigAddModal,
@@ -240,7 +241,10 @@ const Container = ({
       <DialogWrapper>
         <DialogCloseButton onClick={onClose} />
         <DialogTitle>
+          {/* // TODO:Fix typeError */}
+          {/* <NoticeableLetters> */}
           <TextCenteringSpan>{title[configName] + " "}</TextCenteringSpan>
+          {/* </NoticeableLetters> */}
           {getConfigRes ? (
             <SquareIconButton
               onClick={() => setOpenAddModal(true)}

--- a/src/components/organisms/SearchConfigEditModal.tsx
+++ b/src/components/organisms/SearchConfigEditModal.tsx
@@ -26,6 +26,7 @@ import {
   TextCenteringSpan,
   DialogWrapper,
   DialogMain,
+  // NoticeableLetters,
 } from "@dataware-tools/app-common";
 import { produce } from "immer";
 import { mutate } from "swr";
@@ -204,7 +205,10 @@ const Container = ({
       <DialogWrapper>
         <DialogCloseButton onClick={onClose} />
         <DialogTitle>
+          {/* //TODO: Fix typeError */}
+          {/* <NoticeableLetters> */}
           <TextCenteringSpan>{title[configName] + " "}</TextCenteringSpan>
+          {/* </NoticeableLetters> */}
           {getConfigRes ? (
             <SquareIconButton onClick={onAdd} icon={<AddCircleIcon />} />
           ) : null}


### PR DESCRIPTION
## What?
change modal-title fonts in the settings

## Why?
- usermanagerとタイトルのフォントを統一するため
- タイトルを強調するため

## Screenshot or video [Optional]
![image](https://user-images.githubusercontent.com/61043090/122695749-4debaa80-d27c-11eb-9947-9ce0f994bb4d.png)
設定内の4つのモーダル内のタイトルをoxaniumに変更
![image](https://user-images.githubusercontent.com/61043090/122695784-64920180-d27c-11eb-997a-10772acf3bda.png)


