### PR TITLE
setting min-width of input select

### DIFF
--- a/src/components/molecules/DisplayConfigListItem.tsx
+++ b/src/components/molecules/DisplayConfigListItem.tsx
@@ -25,6 +25,9 @@ const useStyles = makeStyles({
     flexDirection: "row",
     justifyContent: "space-between",
   },
+  inputSelect: {
+    minWidth: 400,
+  },
 });
 
 const Component = ({
@@ -42,6 +45,7 @@ const Component = ({
           onChange("change", event.target.value as string, value)
         }
         variant="outlined"
+        className={classes.inputSelect}
       >
         <MenuItem value={value}>
           {options.find((option) => option.value === value)?.label || value}

--- a/src/components/molecules/InputConfigListItem.tsx
+++ b/src/components/molecules/InputConfigListItem.tsx
@@ -39,6 +39,9 @@ const useStyles = makeStyles({
     flexDirection: "row",
     justifyContent: "flex-end",
   },
+  inputSelect: {
+    minWidth: 160,
+  },
 });
 
 const Component = ({ classes, value, onChange }: Props): JSX.Element => {
@@ -64,6 +67,7 @@ const Component = ({ classes, value, onChange }: Props): JSX.Element => {
             )
           }
           variant="outlined"
+          className={classes.inputSelect}
         >
           <MenuItem value="required">Required</MenuItem>
           <MenuItem value="recommended">Recommended</MenuItem>

--- a/src/components/molecules/OptionSharingSelectsItem.tsx
+++ b/src/components/molecules/OptionSharingSelectsItem.tsx
@@ -35,6 +35,9 @@ const useStyles = makeStyles({
     flexDirection: "row",
     justifyContent: "space-between",
   },
+  inputSelect: {
+    minWidth: 400,
+  },
 });
 
 const Component = ({
@@ -57,6 +60,7 @@ const Component = ({
         onChange={(event) =>
           onChange("update", index, event.target.value as string, value)
         }
+        className={classes.inputSelect}
       >
         <MenuItem {...menuItemProps} value={value}>
           {options.find((option) => option.value === value)?.label || value}

--- a/src/components/molecules/SearchConfigListItem.tsx
+++ b/src/components/molecules/SearchConfigListItem.tsx
@@ -25,6 +25,9 @@ const useStyles = makeStyles({
     flexDirection: "row",
     justifyContent: "space-between",
   },
+  inputSelect: {
+    minWidth: 400,
+  },
 });
 
 const Component = ({
@@ -42,6 +45,7 @@ const Component = ({
           onChange("change", event.target.value as string, value)
         }
         variant="outlined"
+        className={classes.inputSelect}
       >
         <MenuItem value={value}>
           {options.find((option) => option.value === value)?.label || value}


### PR DESCRIPTION
## What?
setting min-width of input select

## Why?
モーダル幅がinput-selectの文字数によって変わるのを避けたかったため

## Screenshot or video [Optional]

https://user-images.githubusercontent.com/61043090/123598135-2756e200-d82f-11eb-93b0-78aa5ce6f932.mov


