### PR TITLE
Change more icon to MoreHoriz

### DIFF
--- a/src/components/molecules/DatabaseMenuButton.tsx
+++ b/src/components/molecules/DatabaseMenuButton.tsx
@@ -1,5 +1,5 @@
 import { MouseEvent, useState } from "react";
-import MenuIcon from "@material-ui/icons/Menu";
+import { MoreHoriz as MoreIcon } from "@material-ui/icons";
 import {
   DatabaseMenu,
   DatabaseMenuProps,
@@ -25,7 +25,7 @@ const Component = ({
 }: Props): JSX.Element | null => {
   return (
     <div>
-      <SquareIconButton icon={<MenuIcon />} onClick={onOpen} />
+      <SquareIconButton icon={<MoreIcon />} onClick={onOpen} />
       <DatabaseMenu
         {...delegated}
         onClick={onMenuSelect as (value: string) => void}


### PR DESCRIPTION
## What?

レコード一覧ページ，ヘッダーのオプションまとめたアイコンを3本線ではなく水平に3つの点が並んだアイコンに変更

## Why?

- More的なアイコンはこちらのほうが一般的と思われる
- GitHubを参考にしてます

## See also [Optional]

- Issue: https://github.com/dataware-tools/dataware-tools/issues/32

## Screenshot or video [Optional]

### 変更後

<img width="1914" alt="スクリーンショット 2021-07-15 13 21 20" src="https://user-images.githubusercontent.com/13210107/125728973-8646d856-de16-4c33-a9b6-f3e746688084.png">

### 変更前

<img width="1920" alt="スクリーンショット 2021-07-15 13 22 31" src="https://user-images.githubusercontent.com/13210107/125728987-d4ffd371-4b64-430a-a875-49597eaea6c8.png">
