### PR TITLE
Fix duplicated atom key

### DIFF
--- a/src/globalStates.ts
+++ b/src/globalStates.ts
@@ -38,6 +38,6 @@ type DatabasePaginateState = {
 };
 
 export const databasePaginateState = atom<DatabasePaginateState>({
-  key: "recordPaginateState",
+  key: "databasePaginateState",
   default: { page: 1, perPage: 20, search: "", searchKey: [] },
 });


### PR DESCRIPTION
## What?

atomのキーで被っていたものがあったため変更

## Why?

以下の警告が出ていた

```
Duplicate atom key "recordPaginateState". This is a FATAL ERROR in
      production. But it is safe to ignore this warning if it occurred because of
      hot module replacement.
```
