### PR TITLE
Replace Table of dataware-tools to DataGrid of material-ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2376,6 +2376,17 @@
         }
       }
     },
+    "@material-ui/data-grid": {
+      "version": "4.0.0-alpha.34",
+      "resolved": "https://registry.npmjs.org/@material-ui/data-grid/-/data-grid-4.0.0-alpha.34.tgz",
+      "integrity": "sha512-hXHjyLRKbOk+rObEnQbTzZ8Xgtfn/Li40NVmzkall+eIPktqqJ3GJDzOv0EVD+GGjXDixf+XT9BppjXk87EwiQ==",
+      "requires": {
+        "@material-ui/utils": "^5.0.0-alpha.14",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "reselect": "^4.0.0"
+      }
+    },
     "@material-ui/icons": {
       "version": "5.0.0-alpha.28",
       "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-5.0.0-alpha.28.tgz",
@@ -18597,6 +18608,11 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
     },
     "resolve": {
       "version": "1.20.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@emotion/react": "^11.1.5",
     "@emotion/styled": "^11.1.5",
     "@material-ui/core": "^5.0.0-alpha.30",
+    "@material-ui/data-grid": "^4.0.0-alpha.34",
     "@material-ui/icons": "^5.0.0-alpha.28",
     "@material-ui/lab": "^5.0.0-alpha.30",
     "cross-env": "^7.0.3",

--- a/src/components/organisms/DatabaseList.tsx
+++ b/src/components/organisms/DatabaseList.tsx
@@ -6,13 +6,12 @@ import {
   ErrorMessage,
   ErrorMessageProps,
   LoadingIndicator,
-  Table,
-  TableProps,
 } from "@dataware-tools/app-common";
+import { DataGrid, GridColumns } from "@material-ui/data-grid";
 
 type Props = {
   error?: ErrorMessageProps;
-  columns: TableProps["columns"];
+  columns: GridColumns;
   isFetchComplete: boolean;
   databases: DatabaseListItemProps["database"][];
   onSelectDatabase: (databaseId: string) => void;
@@ -32,14 +31,13 @@ const Component = ({
       {error ? (
         <ErrorMessage {...error} />
       ) : isFetchComplete ? (
-        <Table
+        <DataGrid
           columns={columns}
           rows={databases}
-          disableHoverCell
-          stickyHeader
-          onClickRow={(targetDetail) =>
-            onSelectDatabase(targetDetail.row.database_id as string)
-          }
+          onRowClick={(params) => onSelectDatabase(params.row.database_id)}
+          getRowId={(row) => row.database_id}
+          hideFooter
+          disableColumnMenu
         />
       ) : (
         <LoadingIndicator />
@@ -60,18 +58,20 @@ const Container = ({ page, perPage, search }: ContainerProps): JSX.Element => {
   const onSelectDatabase = (databaseId: string) =>
     history.push(`/databases/${databaseId}/records`);
 
-  const columns = [
+  const columns: GridColumns = [
     {
       field: "name",
-      ifEmpty: "No name...",
-      label: "Name",
-      type: "string" as const,
+      headerName: "Name",
+      flex: 1,
+      valueGetter: (param) => param.row.name || "No name...",
+      sortable: false,
     },
     {
       field: "description",
-      ifEmpty: "No description...",
-      label: "Description",
-      type: "string" as const,
+      headerName: "Description",
+      flex: 1,
+      valueGetter: (param) => param.row.name || "No description...",
+      sortable: false,
     },
   ];
   const error: Props["error"] = listDatabasesError


### PR DESCRIPTION
## What?
- Replace Table of dataware-tools to DataGrid of material-ui

## Why?
- DataGrid have some function helping improvement of data showing page

## See also
Resolves https://github.com/dataware-tools/dataware-tools/issues/29
