### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2509,13 +2509,10 @@
       }
     },
     "@mdn/browser-compat-data": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-2.0.7.tgz",
-      "integrity": "sha512-GeeM827DlzFFidn1eKkMBiqXFD2oLsnZbaiGhByPl0vcapsRzUL+t9hDoov1swc9rB2jw64R+ihtzC8qOE9wXw==",
-      "dev": true,
-      "requires": {
-        "extend": "3.0.2"
-      }
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.3.12.tgz",
+      "integrity": "sha512-XC9Agp7J5JuD/yfSk212MS2iWZnmcdK+JGPh8bULBrTiduFNttcuBGrHfhyy8YNY3BSIO46J8GkcWPln7fe6wA==",
+      "dev": true
     },
     "@mdx-js/loader": {
       "version": "1.6.22",
@@ -6243,10 +6240,13 @@
       "dev": true
     },
     "ast-metadata-inferer": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.4.0.tgz",
-      "integrity": "sha512-tKHdBe8N/Vq2nLAm4YPBVREVZjMux6KrqyPfNQgIbDl0t7HaNSmy8w4OyVHYg/cvyn5BW7o7pVwpjPte89Zhcg==",
-      "dev": true
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.5.1.tgz",
+      "integrity": "sha512-fj+QuB47ODy18p5gJ4BFnpenk992o7gx7oPid6oUK9+Uy/F3/5cvZ13harpQPN5Y8MlcjYf0y1LwgOV1J31k+A==",
+      "dev": true,
+      "requires": {
+        "@mdn/browser-compat-data": "^3.3.11"
+      }
     },
     "ast-types": {
       "version": "0.13.2",
@@ -9938,26 +9938,88 @@
       }
     },
     "eslint-plugin-compat": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-3.9.0.tgz",
-      "integrity": "sha512-lt3l5PHFHVEYSZ5zijcoYvtQJPsBifRiH5N0Et57KwVu7l/yxmHhSG6VJiLMa/lXrg93Qu8049RNQOMn0+yJBg==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-3.11.1.tgz",
+      "integrity": "sha512-iJyltnaVN9g/MYL3WGb6GFyJs+4mMkumq2E5srxsQIfPqQh14HEE0dtQC/HKDWze+hkwQtSo5DvC3IW5Gmxdtw==",
       "dev": true,
       "requires": {
-        "@mdn/browser-compat-data": "^2.0.7",
-        "ast-metadata-inferer": "^0.4.0",
-        "browserslist": "^4.12.2",
-        "caniuse-lite": "^1.0.30001166",
-        "core-js": "^3.6.5",
-        "find-up": "^4.1.0",
+        "@mdn/browser-compat-data": "^3.3.11",
+        "ast-metadata-inferer": "^0.5.1",
+        "browserslist": "^4.16.6",
+        "caniuse-lite": "^1.0.30001245",
+        "core-js": "^3.15.2",
+        "find-up": "^5.0.0",
         "lodash.memoize": "4.1.2",
-        "semver": "7.3.2"
+        "semver": "7.3.5"
       },
       "dependencies": {
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+        "browserslist": {
+          "version": "4.16.6",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+          "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001219",
+            "colorette": "^1.2.2",
+            "electron-to-chromium": "^1.3.723",
+            "escalade": "^3.1.1",
+            "node-releases": "^1.1.71"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001247",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001247.tgz",
+          "integrity": "sha512-4rS7co+7+AoOSPRPOPUt5/GdaqZc0EsUpWk66ofE3HJTAajUK2Ss2VwoNzVN69ghg8lYYlh0an0Iy4LIHHo9UQ==",
           "dev": true
+        },
+        "core-js": {
+          "version": "3.15.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.2.tgz",
+          "integrity": "sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q==",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.787",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.787.tgz",
+          "integrity": "sha512-zeM5AFwvTlSYvGpBaFZKVo7GQEWSk6hS3rQ7mdrr3qB7CiqVl84K6nIPznyKSu0b8ABiEeMEIqyBuzqMkxnjjg==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint-config-standard-react": "^9.2.0",
     "eslint-config-standard-with-typescript": "^20.0.0",
     "eslint-import-resolver-typescript": "^2.4.0",
-    "eslint-plugin-compat": "^3.9.0",
+    "eslint-plugin-compat": "^3.11.1",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsx-a11y": "^6.4.1",

--- a/src/components/molecules/FilePreviewer/RosbagPreviewer/JobViewer.tsx
+++ b/src/components/molecules/FilePreviewer/RosbagPreviewer/JobViewer.tsx
@@ -104,10 +104,8 @@ export const JobViewer = ({ job, jobType }: JobViewerProps): JSX.Element => {
     .map(([key]) => job.output[key]);
   const error =
     job.output.code !== 200
-      ? // @ts-expect-error Fix API
-        job.output.reason
-        ? // @ts-expect-error Fix API
-          { reason: job.output.reason }
+      ? job.output.reason
+        ? { reason: job.output.reason }
         : { reason: "unknown Error" }
       : undefined;
 


### PR DESCRIPTION
## What?
This patch includes the following updates:
- Bump eslint-plugin-compat from 3.9.0 to 3.11.1 #104
- Bump eslint-config-standard from 16.0.2 to 16.0.3 #103
- Bump eslint-plugin-react from 7.23.2 to 7.24.0 #100
- Bump react-dom from 17.0.1 to 17.0.2 #98
- Bump @testing-library/user-event from 13.1.5 to 13.2.1 #97

## Why?
To update dependencies
