### PR TITLE
Add initial config for easy starting to use database

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -143,6 +143,17 @@ const initializeDatabaseConfig = async (
         ...currentConfig,
         columns: [
           {
+            name: "record_name",
+            display_name: "Record name",
+            dtype: "string",
+            aggregation: "first",
+            is_display_field: true,
+            is_search_target: true,
+            is_record_title: true,
+            order_of_input: 0,
+            necessity: "required",
+          },
+          {
             name: "created_by",
             display_name: "Created by",
             dtype: "string",


### PR DESCRIPTION
## What?
- Add initial config

## Why?
- For easy starting to use database

## See also
- Resolves https://github.com/dataware-tools/dataware-tools/issues/40

## Screenshot or video
![InitialConfigForEasyUsing](https://user-images.githubusercontent.com/72174933/127989914-01c9667a-9c52-4fe1-8123-96ae88b514af.gif)

