### PR TITLE
Change searching UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1399,9 +1399,9 @@
       }
     },
     "@dataware-tools/app-common": {
-      "version": "21.7.7",
-      "resolved": "https://npm.pkg.github.com/download/@dataware-tools/app-common/21.7.7/4c8b19997595ce691d0ff6c607290b1517dc0194b933c1edb8ff2a341bfa6420",
-      "integrity": "sha512-Rm2/O7nZo1ZHaG3Ht9cvGnvLnK/CRKDCzp/apw8rUK+2uvwNYe/jkSIltDauA75tiw3m5TrAm+TCXJT4c5CjWw=="
+      "version": "21.8.2",
+      "resolved": "https://npm.pkg.github.com/download/@dataware-tools/app-common/21.8.2/34481c363c1c6ab0247d30335dd5609360af234f7d706c8af8cace94a2c094e1",
+      "integrity": "sha512-VP0kdojM2p3d++JW+4N4k3ubGHbfZCKCYFMIYzpCcDpBoAHug0t7YfJU52Gk8H5rxn6ljIQUbs9QIvmpk6OBpA=="
     },
     "@date-io/core": {
       "version": "2.10.7",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@auth0/auth0-react": "^1.4.0",
-    "@dataware-tools/app-common": "^21.7.7",
+    "@dataware-tools/app-common": "^21.8.2",
     "@emotion/react": "^11.1.5",
     "@emotion/styled": "^11.1.5",
     "@material-ui/core": "^5.0.0-alpha.30",

--- a/src/components/molecules/SearchButton.stories.tsx
+++ b/src/components/molecules/SearchButton.stories.tsx
@@ -1,0 +1,12 @@
+import { Story } from "@storybook/react";
+import { SearchButton, SearchButtonProps } from "./SearchButton";
+
+export default {
+  component: SearchButton,
+  title: "SearchButton",
+};
+
+const Template: Story<SearchButtonProps> = (args) => <SearchButton {...args} />;
+
+export const Default = Template.bind({});
+Default.args = { onSearch: (text) => window.alert(text) };

--- a/src/components/molecules/SearchButton.tsx
+++ b/src/components/molecules/SearchButton.tsx
@@ -1,0 +1,52 @@
+import {
+  SearchFormModal,
+  SearchFormModalProps,
+} from "components/molecules/SearchFormModal";
+import IconButton from "@material-ui/core/IconButton";
+import SearchIcon from "@material-ui/icons/Search";
+import { useState } from "react";
+export type SearchButtonDOMProps = {
+  onOpenSearchFormModal: () => void;
+  isOpenSearchFormModal: boolean;
+  onCloseSearchFormModal: () => void;
+} & SearchButtonProps;
+
+export type SearchButtonProps = {
+  onSearch: (searchText: string) => void;
+  defaultSearchText: SearchFormModalProps["defaultSearchText"];
+};
+
+export const SearchButtonDOM = (props: SearchButtonDOMProps): JSX.Element => {
+  const {
+    onSearch,
+    onOpenSearchFormModal,
+    defaultSearchText,
+    isOpenSearchFormModal,
+    onCloseSearchFormModal,
+  } = props;
+  return (
+    <>
+      <IconButton onClick={onOpenSearchFormModal} size="small">
+        <SearchIcon />
+      </IconButton>
+      <SearchFormModal
+        open={isOpenSearchFormModal}
+        onClose={onCloseSearchFormModal}
+        defaultSearchText={defaultSearchText}
+        onSearch={onSearch}
+      />
+    </>
+  );
+};
+
+export const SearchButton = (props: SearchButtonProps): JSX.Element => {
+  const [isOpenSearchFormModal, setIsOpenSearchFormModal] = useState(false);
+  return (
+    <SearchButtonDOM
+      isOpenSearchFormModal={isOpenSearchFormModal}
+      onOpenSearchFormModal={() => setIsOpenSearchFormModal(true)}
+      onCloseSearchFormModal={() => setIsOpenSearchFormModal(false)}
+      {...props}
+    />
+  );
+};

--- a/src/components/molecules/SearchFormModal.stories.tsx
+++ b/src/components/molecules/SearchFormModal.stories.tsx
@@ -1,0 +1,18 @@
+import { Story } from "@storybook/react";
+import { SearchFormModal, SearchFormModalProps } from "./SearchFormModal";
+
+export default {
+  component: SearchFormModal,
+  title: "SearchFormModal",
+};
+
+const Template: Story<SearchFormModalProps> = (args) => (
+  <SearchFormModal {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  open: true,
+  onSearch: (text) => window.alert(text),
+  onClose: () => window.alert("close"),
+};

--- a/src/components/molecules/SearchFormModal.tsx
+++ b/src/components/molecules/SearchFormModal.tsx
@@ -1,0 +1,65 @@
+import {
+  theme as themeInstance,
+  DialogCloseButton,
+  DialogContainer,
+  DialogBody,
+  DialogWrapper,
+  DialogMain,
+  SearchForm,
+  SearchFormProps,
+} from "@dataware-tools/app-common";
+import { makeStyles } from "@material-ui/core/styles";
+import Dialog, { DialogProps } from "@material-ui/core/Dialog";
+
+export type SearchFormModalDOMProps = {
+  onSearch: SearchFormProps["onSearch"];
+} & Omit<SearchFormModalProps, "onSearch">;
+
+export type SearchFormModalProps = {
+  onClose: () => void;
+  onSearch: (searchText: string) => void;
+  defaultSearchText: SearchFormProps["defaultValue"];
+} & Omit<DialogProps, "onClose">;
+
+export const useStyles = makeStyles((theme: typeof themeInstance) => ({
+  sample: {
+    "&:hover": {
+      backgroundColor: theme.palette.action.hover,
+    },
+  },
+}));
+
+export const SearchFormModalDOM = (
+  props: SearchFormModalDOMProps
+): JSX.Element => {
+  const { onClose, onSearch, defaultSearchText, ...dialogProps } = props;
+  return (
+    <Dialog {...dialogProps} onClose={onClose} maxWidth="xl">
+      <DialogWrapper>
+        <DialogCloseButton onClick={onClose} />
+        <DialogContainer>
+          <DialogBody>
+            <DialogMain width="80vw">
+              <SearchForm
+                onSearch={onSearch}
+                defaultValue={defaultSearchText}
+                inputProps={{ autoFocus: true, fullWidth: true }}
+              />
+            </DialogMain>
+          </DialogBody>
+        </DialogContainer>
+      </DialogWrapper>
+    </Dialog>
+  );
+};
+
+export const SearchFormModal = (props: SearchFormModalProps): JSX.Element => {
+  const { onSearch: propsOnSearch, onClose, ...delegated } = props;
+  const onSearch: SearchFormModalDOMProps["onSearch"] = (text) => {
+    propsOnSearch(text);
+    onClose();
+  };
+  return (
+    <SearchFormModalDOM onSearch={onSearch} onClose={onClose} {...delegated} />
+  );
+};

--- a/src/components/pages/DatabasesPage.tsx
+++ b/src/components/pages/DatabasesPage.tsx
@@ -3,7 +3,6 @@ import {
   addQueryString,
   ErrorMessage,
   LoadingIndicator,
-  SearchForm,
   Spacer,
   PerPageSelect,
   PageContainer,
@@ -29,6 +28,7 @@ import {
   DatabaseAddButtonProps,
 } from "components/organisms/DatabaseAddButton";
 import { useHistory } from "react-router-dom";
+import { SearchButton } from "components/molecules/SearchButton";
 
 type Props = {
   error?: ErrorMessageProps;
@@ -70,9 +70,9 @@ const Component = ({
             right={
               isFetchComplete ? (
                 <>
-                  <SearchForm
+                  <SearchButton
+                    defaultSearchText={searchText}
                     onSearch={onChangeSearchText}
-                    defaultValue={searchText}
                   />
                   <Spacer direction="horizontal" size="15px" />
                   <PerPageSelect
@@ -146,7 +146,11 @@ const Container = (): JSX.Element => {
     setDatabasePaginateState((prev) => ({ ...prev, perPage }));
   };
   const onChangeSearchText: Props["onChangeSearchText"] = (searchText) => {
-    setDatabasePaginateState((prev) => ({ ...prev, search: searchText }));
+    setDatabasePaginateState((prev) => ({
+      ...prev,
+      search: searchText,
+      page: 1,
+    }));
   };
 
   const onAddDatabaseSucceeded: Props["onAddDatabaseSucceeded"] = (

--- a/src/components/pages/RecordsPage.tsx
+++ b/src/components/pages/RecordsPage.tsx
@@ -3,7 +3,6 @@ import {
   addQueryString,
   ErrorMessage,
   LoadingIndicator,
-  SearchForm,
   Spacer,
   PerPageSelect,
   PageContainer,
@@ -51,6 +50,7 @@ import {
 
 import { Breadcrumbs } from "components/molecules/Breadcrumbs";
 import StorageIcon from "@material-ui/icons/Storage";
+import { SearchButton } from "components/molecules/SearchButton";
 
 type Props = {
   error?: ErrorMessageProps;
@@ -109,9 +109,9 @@ const Component = ({
             right={
               isFetchComplete ? (
                 <>
-                  <SearchForm
+                  <SearchButton
+                    defaultSearchText={searchText}
                     onSearch={onChangeSearchText}
-                    defaultValue={searchText}
                   />
                   <Spacer direction="horizontal" size="15px" />
                   <PerPageSelect
@@ -280,7 +280,11 @@ const Page = (): JSX.Element => {
     setRecordPaginateState((prev) => ({ ...prev, perPage }));
   };
   const onChangeSearchText: Props["onChangeSearchText"] = (searchText) => {
-    setRecordPaginateState((prev) => ({ ...prev, search: searchText }));
+    setRecordPaginateState((prev) => ({
+      ...prev,
+      search: searchText,
+      page: 1,
+    }));
   };
   const onEndInitializeDatabase: Props["onEndInitializeDatabase"] = () => {
     setIsNewDatabase(false);


### PR DESCRIPTION
## What?
- Change searching UX

## Why?
- 長いクエリを書くことを考えると検索欄が小さすぎたから
- 逐次的な検索を行わない現状だと，モーダルを開いても使用感はそう変わらないと思ったから
- 詳細検索か簡易検索を選べるようにすると，モーダルを開くことになる気がするから

## See also
- Resolves https://github.com/dataware-tools/dataware-tools/issues/14
- Depends on https://github.com/dataware-tools/app-common/pull/84

## Screenshot or video
![ChangeUXofSearchingData](https://user-images.githubusercontent.com/72174933/128147035-66ada022-0d0f-4c50-abc3-ac510d174486.gif)

