### PR TITLE
Rewrite Sample component by new coding style

### DIFF
--- a/src/components/molecules/Sample.tsx
+++ b/src/components/molecules/Sample.tsx
@@ -1,9 +1,8 @@
-import Button from "@material-ui/core/Button";
-
 import { useAuth0 } from "@auth0/auth0-react";
+import Button from "@material-ui/core/Button";
+import Typography from "@material-ui/core/Typography";
 import { mutate } from "swr";
 import { useListDatabases } from "utils/index";
-import Typography from "@material-ui/core/Typography";
 
 export type SamplePresentationProps = {
   user: any;

--- a/src/components/molecules/Sample.tsx
+++ b/src/components/molecules/Sample.tsx
@@ -1,13 +1,11 @@
-import { theme as themeInstance } from "@dataware-tools/app-common";
-import { makeStyles } from "@material-ui/core/styles";
-
 import Button from "@material-ui/core/Button";
 
 import { useAuth0 } from "@auth0/auth0-react";
 import { mutate } from "swr";
 import { useListDatabases } from "utils/index";
+import Typography from "@material-ui/core/Typography";
 
-export type SampleDOMProps = {
+export type SamplePresentationProps = {
   user: any;
   onRevalidate: () => void;
   error: any;
@@ -18,20 +16,18 @@ export type SampleProps = {
   sample: string;
 };
 
-export const useStyles = makeStyles((theme: typeof themeInstance) => ({
-  sample: {
-    "&:hover": {
-      backgroundColor: theme.palette.action.hover,
-    },
-  },
-}));
-
-export const SampleDOM = (props: SampleDOMProps): JSX.Element => {
+export const SamplePresentation = (
+  props: SamplePresentationProps
+): JSX.Element => {
   const { onRevalidate, user, error, data, sample } = props;
-  const classes = useStyles();
   return (
     <div>
-      <h1 className={classes.sample}>Hello {user ? user.name : "world"}</h1>
+      <Typography
+        variant="h3"
+        sx={{ ":hover": { backgroundColor: "action.hover" } }}
+      >
+        Hello {user ? user.name : "world"}
+      </Typography>
       <div>this is {sample}</div>
       <Button onClick={onRevalidate}>revalidate API</Button>
       {error ? (
@@ -52,7 +48,7 @@ export const Sample = (props: SampleProps): JSX.Element => {
   };
 
   return (
-    <SampleDOM
+    <SamplePresentation
       user={user}
       data={data}
       error={error}

--- a/src/components/molecules/Sample.tsx
+++ b/src/components/molecules/Sample.tsx
@@ -7,26 +7,28 @@ import { useAuth0 } from "@auth0/auth0-react";
 import { mutate } from "swr";
 import { useListDatabases } from "utils/index";
 
-type Props = {
-  classes: ReturnType<typeof useStyles>;
+export type SampleDOMProps = {
   user: any;
   onRevalidate: () => void;
   error: any;
   data: any;
-} & ContainerProps;
+} & SampleProps;
 
-type ContainerProps = {
+export type SampleProps = {
   sample: string;
 };
 
-const Component = ({
-  classes,
-  onRevalidate,
-  user,
-  error,
-  data,
-  sample,
-}: Props): JSX.Element => {
+export const useStyles = makeStyles((theme: typeof themeInstance) => ({
+  sample: {
+    "&:hover": {
+      backgroundColor: theme.palette.action.hover,
+    },
+  },
+}));
+
+export const SampleDOM = (props: SampleDOMProps): JSX.Element => {
+  const { onRevalidate, user, error, data, sample } = props;
+  const classes = useStyles();
   return (
     <div>
       <h1 className={classes.sample}>Hello {user ? user.name : "world"}</h1>
@@ -41,16 +43,8 @@ const Component = ({
   );
 };
 
-const useStyles = makeStyles((theme: typeof themeInstance) => ({
-  sample: {
-    "&:hover": {
-      backgroundColor: theme.palette.action.hover,
-    },
-  },
-}));
-
-const Container = ({ ...delegated }: ContainerProps): JSX.Element => {
-  const classes = useStyles();
+export const Sample = (props: SampleProps): JSX.Element => {
+  const { ...delegated } = props;
   const { user, getAccessTokenSilently: getAccessToken } = useAuth0();
   const { data, error, cacheKey } = useListDatabases(getAccessToken, {});
   const onRevalidate = () => {
@@ -58,8 +52,7 @@ const Container = ({ ...delegated }: ContainerProps): JSX.Element => {
   };
 
   return (
-    <Component
-      classes={classes}
+    <SampleDOM
       user={user}
       data={data}
       error={error}
@@ -68,6 +61,3 @@ const Container = ({ ...delegated }: ContainerProps): JSX.Element => {
     />
   );
 };
-
-export { Container as Sample };
-export type { ContainerProps as SampleProps };


### PR DESCRIPTION
## What?
- Rewrite Sample component by new coding style

## Why?
- 今のコーディングスタイルでは幾つか不便な点があったから
  - **`TypeError: "x" has no properties ` といったエラーが起きた場合には，スタックトレースに表示されるコンポーネント名が `Component$3` や `Container$7` 等になるため，どこでバグが起きているのか追いづらかった**
  - **ロジックコンポーネントで `useStyles` を使っているので，Storybook でビュー側だけを利用しようとした場合に面倒が多かった**
  - **ロジックコンポーネントで `useStyles` を使っているので，特にロジックがなくてもスタイルが付くだけでロジックコンポーネントを用意しなくてはならなかった**
  - IDE 等で定義に飛んだ結果，カーソルが当たる部分が `Container` になるため，初見で理解しづらかった
  - 分割代入の記法と関数コンポーネントの記法に習熟していないと入力と出力の型を追いづらかった

## See also
- 現状感じているこの書き方の辛い点
  - ロジック側でビューの props の型を参照するときに，今までは `Props["hoge"]` で済んでいたのが，`SomeNameDOMProps["hoge"]` となり，多少面倒
  - ビューコンポーネントが `useStyles` を含むので，Material-UI から離れる時にビューコンポーネントをそのままは流用出来ない
