### PR TITLE
Show easy understood message when fetch error occur

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1399,9 +1399,9 @@
       }
     },
     "@dataware-tools/app-common": {
-      "version": "21.7.7",
-      "resolved": "https://npm.pkg.github.com/download/@dataware-tools/app-common/21.7.7/4c8b19997595ce691d0ff6c607290b1517dc0194b933c1edb8ff2a341bfa6420",
-      "integrity": "sha512-Rm2/O7nZo1ZHaG3Ht9cvGnvLnK/CRKDCzp/apw8rUK+2uvwNYe/jkSIltDauA75tiw3m5TrAm+TCXJT4c5CjWw=="
+      "version": "21.8.4",
+      "resolved": "https://npm.pkg.github.com/download/@dataware-tools/app-common/21.8.4/8a1e34e1c41cd0453b2c031b759688b6a546ed0f7b55311433bb21804759c44e",
+      "integrity": "sha512-Rg1zobF00XAUZvo20v6VmDmnU8aFlumpGrlhij9CaKXO7Kdvez5jgbZ1x1uEUa481UTiI6RF/pMBGAuZBRXaHg=="
     },
     "@date-io/core": {
       "version": "2.10.7",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@auth0/auth0-react": "^1.4.0",
-    "@dataware-tools/app-common": "^21.7.7",
+    "@dataware-tools/app-common": "^21.8.4",
     "@emotion/react": "^11.1.5",
     "@emotion/styled": "^11.1.5",
     "@material-ui/core": "^5.0.0-alpha.30",

--- a/src/components/molecules/FilePreviewer/RosbagPreviewer/index.tsx
+++ b/src/components/molecules/FilePreviewer/RosbagPreviewer/index.tsx
@@ -4,11 +4,11 @@ import {
   ErrorMessageProps,
   DialogTitle,
   ErrorMessage,
+  extractErrorMessageFromFetchError,
 } from "@dataware-tools/app-common";
 import { useAuth0 } from "@auth0/auth0-react";
 import { JobSubmitter } from "./JobSubmitter";
 import {
-  extractReasonFromFetchError,
   fetchJobStore,
   useGetJobTemplate,
   useGetJobTypes,
@@ -91,10 +91,10 @@ export const RosbagPreviewer = ({
     listJobTemplateError || getJobTemplateError || getJobTypeError;
   useEffect(() => {
     if (fetchError) {
-      setError({
-        reason: extractReasonFromFetchError(fetchError),
-        instruction: "Please reload this page",
-      });
+      const { reason, instruction } = extractErrorMessageFromFetchError(
+        fetchError
+      );
+      setError({ reason, instruction });
     } else {
       setError(undefined);
     }
@@ -115,10 +115,8 @@ export const RosbagPreviewer = ({
       }
     );
     if (error) {
-      setError({
-        reason: extractReasonFromFetchError(error),
-        instruction: "Please reload this page",
-      });
+      const { reason, instruction } = extractErrorMessageFromFetchError(error);
+      setError({ reason, instruction });
     } else {
       setJob(data);
     }

--- a/src/components/organisms/DatabaseEditModal.tsx
+++ b/src/components/organisms/DatabaseEditModal.tsx
@@ -11,6 +11,7 @@ import {
   ErrorMessageProps,
   ErrorMessage,
   usePrevious,
+  extractErrorMessageFromFetchError,
 } from "@dataware-tools/app-common";
 import { useAuth0 } from "@auth0/auth0-react";
 import Box from "@material-ui/core/Box";
@@ -29,7 +30,6 @@ import LoadingButton from "@material-ui/lab/LoadingButton";
 import { useRecoilValue } from "recoil";
 import { databasePaginateState } from "globalStates";
 import {
-  extractReasonFromFetchError,
   initializeDatabaseConfig,
   useGetDatabase,
   useListDatabases,
@@ -208,10 +208,8 @@ const Container = <T extends boolean>({
           databaseId: requestBody.database_id,
         }
       );
-      setError({
-        reason: extractReasonFromFetchError(error),
-        instruction: "Please reload this page",
-      });
+      const { reason, instruction } = extractErrorMessageFromFetchError(error);
+      setError({ reason, instruction });
     };
 
     const [saveDatabaseRes, saveDatabaseError] =
@@ -230,12 +228,14 @@ const Container = <T extends boolean>({
           );
 
     if (saveDatabaseError) {
-      add
-        ? procAfterFailAdd(saveDatabaseError)
-        : setError({
-            reason: extractReasonFromFetchError(saveDatabaseError),
-            instruction: "Please reload this page",
-          });
+      if (add) {
+        procAfterFailAdd(saveDatabaseError);
+      } else {
+        const { reason, instruction } = extractErrorMessageFromFetchError(
+          saveDatabaseError
+        );
+        setError({ reason, instruction: instruction });
+      }
       return;
     }
 

--- a/src/components/organisms/DatabaseList.tsx
+++ b/src/components/organisms/DatabaseList.tsx
@@ -1,15 +1,12 @@
 import { DatabaseListItemProps } from "components/organisms/DatabaseListItem";
 import { useAuth0 } from "@auth0/auth0-react";
 import { useHistory } from "react-router-dom";
-import {
-  extractReasonFromFetchError,
-  ParamTypeListDatabases,
-  useListDatabases,
-} from "utils";
+import { ParamTypeListDatabases, useListDatabases } from "utils";
 import {
   confirm,
   ErrorMessage,
   ErrorMessageProps,
+  extractErrorMessageFromFetchError,
   fetchMetaStore,
   LoadingIndicator,
   metaStore,
@@ -76,10 +73,10 @@ const Container = ({ page, perPage, search }: ContainerProps): JSX.Element => {
   const fetchError = listDatabasesError;
   useEffect(() => {
     if (fetchError) {
-      setError({
-        reason: extractReasonFromFetchError(fetchError),
-        instruction: "Please reload this page",
-      });
+      const { reason, instruction } = extractErrorMessageFromFetchError(
+        fetchError
+      );
+      setError({ reason, instruction });
     } else {
       setError(undefined);
     }
@@ -110,10 +107,10 @@ const Container = ({ page, perPage, search }: ContainerProps): JSX.Element => {
       );
 
       if (deleteDatabaseError) {
-        setError({
-          reason: extractReasonFromFetchError(deleteDatabaseError),
-          instruction: "Please reload this page",
-        });
+        const { reason, instruction } = extractErrorMessageFromFetchError(
+          deleteDatabaseError
+        );
+        setError({ reason, instruction });
       } else if (deleteDatabaseRes) {
         listDatabaseMutate();
       }

--- a/src/components/organisms/DisplayConfigEditModal.tsx
+++ b/src/components/organisms/DisplayConfigEditModal.tsx
@@ -16,17 +16,13 @@ import {
   NoticeableLetters,
   usePrevious,
   ErrorMessageProps,
+  extractErrorMessageFromFetchError,
 } from "@dataware-tools/app-common";
 import LoadingButton, {
   LoadingButtonProps,
 } from "@material-ui/lab/LoadingButton";
 import { SoloSelect, SoloSelectProps } from "components/molecules/SoloSelect";
-import {
-  useGetConfig,
-  fetchMetaStore,
-  compStr,
-  extractReasonFromFetchError,
-} from "utils";
+import { useGetConfig, fetchMetaStore, compStr } from "utils";
 
 import {
   OptionSharingSelects,
@@ -151,10 +147,10 @@ const Container = ({
   const fetchError = getConfigError;
   useEffect(() => {
     if (fetchError) {
-      setError({
-        reason: extractReasonFromFetchError(fetchError),
-        instruction: "Please reload this page",
-      });
+      const { reason, instruction } = extractErrorMessageFromFetchError(
+        fetchError
+      );
+      setError({ reason, instruction });
     } else {
       setError(undefined);
     }
@@ -216,10 +212,10 @@ const Container = ({
       );
 
       if (updateConfigError) {
-        setError({
-          reason: extractReasonFromFetchError(fetchError),
-          instruction: "Please reload this page",
-        });
+        const { reason, instruction } = extractErrorMessageFromFetchError(
+          updateConfigError
+        );
+        setError({ reason, instruction });
       } else {
         getConfigMutate(updateConfigRes);
       }

--- a/src/components/organisms/ExportMetadataModal.tsx
+++ b/src/components/organisms/ExportMetadataModal.tsx
@@ -1,7 +1,7 @@
 import Dialog from "@material-ui/core/Dialog";
 import { useState, useEffect } from "react";
 import LoadingButton from "@material-ui/lab/LoadingButton";
-import { extractReasonFromFetchError, useListRecords } from "utils/index";
+import { useListRecords } from "utils/index";
 import Select from "@material-ui/core/Select";
 import MenuItem from "@material-ui/core/MenuItem";
 import InputLabel from "@material-ui/core/InputLabel";
@@ -20,6 +20,7 @@ import {
   ErrorMessageProps,
   ErrorMessage,
   alert,
+  extractErrorMessageFromFetchError,
 } from "@dataware-tools/app-common";
 import { useAuth0 } from "@auth0/auth0-react";
 
@@ -139,10 +140,10 @@ const Container = ({
   const fetchError = listRecordsError;
   useEffect(() => {
     if (fetchError) {
-      setError({
-        reason: extractReasonFromFetchError(fetchError),
-        instruction: "Please reload this page",
-      });
+      const { reason, instruction } = extractErrorMessageFromFetchError(
+        fetchError
+      );
+      setError({ reason, instruction });
     } else {
       setError(undefined);
     }

--- a/src/components/organisms/FileEditModal.tsx
+++ b/src/components/organisms/FileEditModal.tsx
@@ -1,8 +1,11 @@
-import { ErrorMessageProps, metaStore } from "@dataware-tools/app-common";
+import {
+  ErrorMessageProps,
+  extractErrorMessageFromFetchError,
+  metaStore,
+} from "@dataware-tools/app-common";
 import { useAuth0 } from "@auth0/auth0-react";
 import { useEffect, useMemo, useState } from "react";
 import {
-  extractReasonFromFetchError,
   compInputFields,
   fetchMetaStore,
   useGetConfig,
@@ -77,10 +80,10 @@ const Container = ({
   const fetchError = getFileError || getConfigError;
   useEffect(() => {
     if (fetchError) {
-      setError({
-        reason: extractReasonFromFetchError(fetchError),
-        instruction: "Please reload this page",
-      });
+      const { reason, instruction } = extractErrorMessageFromFetchError(
+        fetchError
+      );
+      setError({ reason, instruction });
     } else {
       setError(undefined);
     }
@@ -98,10 +101,10 @@ const Container = ({
     );
 
     if (saveFileError) {
-      setError({
-        reason: extractReasonFromFetchError(saveFileError),
-        instruction: "Please reload this page",
-      });
+      const { reason, instruction } = extractErrorMessageFromFetchError(
+        saveFileError
+      );
+      setError({ reason, instruction });
       return false;
     }
 

--- a/src/components/organisms/FileList.tsx
+++ b/src/components/organisms/FileList.tsx
@@ -15,6 +15,7 @@ import {
   confirm,
   ErrorMessage,
   ErrorMessageProps,
+  extractErrorMessageFromFetchError,
   fileProvider,
   LoadingIndicator,
   metaStore,
@@ -192,10 +193,7 @@ const Container = ({ databaseId, recordId }: ContainerProps): JSX.Element => {
   const onCloseFileEditModal = () => setEditingFile(undefined);
   const files = listFilesRes?.data || [];
   const error: Props["error"] = listFilesError
-    ? {
-        reason: JSON.stringify(listFilesError),
-        instruction: "Please reload this page",
-      }
+    ? extractErrorMessageFromFetchError(listFilesError)
     : undefined;
   const isFetchComplete = Boolean(!error && listFilesRes);
 

--- a/src/components/organisms/InputConfigEditModal.tsx
+++ b/src/components/organisms/InputConfigEditModal.tsx
@@ -1,12 +1,7 @@
 import Dialog from "@material-ui/core/Dialog";
 import { useState, useEffect } from "react";
 import LoadingButton from "@material-ui/lab/LoadingButton";
-import {
-  useGetConfig,
-  fetchMetaStore,
-  isEditableColumnName,
-  extractReasonFromFetchError,
-} from "utils";
+import { useGetConfig, fetchMetaStore, isEditableColumnName } from "utils";
 import {
   InputConfigList,
   InputConfigListProps,
@@ -26,6 +21,7 @@ import {
   NoticeableLetters,
   LoadingIndicator,
   ErrorMessageProps,
+  extractErrorMessageFromFetchError,
 } from "@dataware-tools/app-common";
 import { produce } from "immer";
 
@@ -114,10 +110,10 @@ const Container = ({
   const fetchError = getConfigError;
   useEffect(() => {
     if (fetchError) {
-      setError({
-        reason: extractReasonFromFetchError(fetchError),
-        instruction: "Please reload this page",
-      });
+      const { reason, instruction } = extractErrorMessageFromFetchError(
+        fetchError
+      );
+      setError({ reason, instruction });
     } else {
       setError(undefined);
     }
@@ -192,10 +188,10 @@ const Container = ({
       );
 
       if (updateConfigError) {
-        setError({
-          reason: extractReasonFromFetchError(updateConfigError),
-          instruction: "Please reload this page",
-        });
+        const { reason, instruction } = extractErrorMessageFromFetchError(
+          updateConfigError
+        );
+        setError({ reason, instruction });
       } else {
         getConfigMutate(updateConfigRes);
       }

--- a/src/components/organisms/RecordDetailModal.tsx
+++ b/src/components/organisms/RecordDetailModal.tsx
@@ -16,6 +16,7 @@ import {
   ErrorMessageProps,
   confirm,
   alert,
+  extractErrorMessageFromFetchError,
 } from "@dataware-tools/app-common";
 import Dialog from "@material-ui/core/Dialog";
 import { useState, useEffect } from "react";
@@ -28,7 +29,6 @@ import {
   uploadFileToFileProvider,
   useGetConfig,
   createSystemMetadata,
-  extractReasonFromFetchError,
 } from "utils";
 import {
   RecordEditModal,
@@ -222,7 +222,7 @@ const Container = ({
     if (createFileError) {
       await alert({
         title: "Fail to upload",
-        body: extractReasonFromFetchError(createFileError),
+        body: extractErrorMessageFromFetchError(createFileError).reason,
       });
       setIsAddingFile(false);
       return;

--- a/src/components/organisms/RecordEditModal.tsx
+++ b/src/components/organisms/RecordEditModal.tsx
@@ -1,4 +1,8 @@
-import { ErrorMessageProps, metaStore } from "@dataware-tools/app-common";
+import {
+  ErrorMessageProps,
+  extractErrorMessageFromFetchError,
+  metaStore,
+} from "@dataware-tools/app-common";
 import { useAuth0 } from "@auth0/auth0-react";
 import { useEffect, useMemo, useState } from "react";
 import { useRecoilValue } from "recoil";
@@ -10,7 +14,6 @@ import {
   useListRecords,
   editableColumnDtype,
   isEditableColumnName,
-  extractReasonFromFetchError,
 } from "utils";
 import {
   MetadataEditModal,
@@ -81,10 +84,10 @@ const Container = ({
   const fetchError = getRecordError || getConfigError;
   useEffect(() => {
     if (fetchError) {
-      setError({
-        reason: extractReasonFromFetchError(fetchError),
-        instruction: "Please reload this page",
-      });
+      const { reason, instruction } = extractErrorMessageFromFetchError(
+        fetchError
+      );
+      setError({ reason, instruction });
     } else if (create && fields.length <= 0) {
       setError({
         reason: "Input fields is not configured",
@@ -118,10 +121,10 @@ const Container = ({
         );
 
     if (saveRecordError) {
-      setError({
-        reason: JSON.stringify(saveRecordError),
-        instruction: "Please reload thi page",
-      });
+      const { reason, instruction } = extractErrorMessageFromFetchError(
+        saveRecordError
+      );
+      setError({ reason, instruction });
       return false;
     }
 

--- a/src/components/organisms/RecordInfo.tsx
+++ b/src/components/organisms/RecordInfo.tsx
@@ -1,6 +1,7 @@
 import {
   ErrorMessage,
   ErrorMessageProps,
+  extractErrorMessageFromFetchError,
   LoadingIndicator,
   metaStore,
   ToolBar,
@@ -86,11 +87,9 @@ const Container = ({ databaseId, recordId }: ContainerProps): JSX.Element => {
       (path: string) => !["", "/", "./.", "./", "/.", "."].includes(path)
     );
   }
+
   const error: Props["error"] = getRecordError
-    ? {
-        reason: JSON.stringify(getRecordError),
-        instruction: "Please reload this page",
-      }
+    ? extractErrorMessageFromFetchError(getRecordError)
     : undefined;
   const isFetchComplete = Boolean(!error && getRecordRes);
   const onToggleIsJsonView = () => {

--- a/src/components/organisms/RecordList.tsx
+++ b/src/components/organisms/RecordList.tsx
@@ -2,6 +2,7 @@ import {
   confirm,
   ErrorMessage,
   ErrorMessageProps,
+  extractErrorMessageFromFetchError,
   metaStore,
 } from "@dataware-tools/app-common";
 import { RecordDetailModal } from "components/organisms/RecordDetailModal";
@@ -11,7 +12,6 @@ import {
   fetchMetaStore,
   useListRecords,
   ParamTypeListRecords,
-  extractReasonFromFetchError,
 } from "utils";
 import { useAuth0 } from "@auth0/auth0-react";
 import { useEffect, useState } from "react";
@@ -143,10 +143,10 @@ const Container = ({
       );
 
       if (deleteRecordError) {
-        setError({
-          reason: extractReasonFromFetchError(deleteRecordError),
-          instruction: "Please reload this page",
-        });
+        const { reason, instruction } = extractErrorMessageFromFetchError(
+          deleteRecordError
+        );
+        setError({ reason, instruction });
       } else if (deleteRecordRes) {
         listRecordsMutate();
       }
@@ -195,10 +195,10 @@ const Container = ({
   const fetchError = listRecordsError || getConfigError;
   useEffect(() => {
     if (fetchError) {
-      setError({
-        reason: extractReasonFromFetchError(fetchError),
-        instruction: "Please reload this page",
-      });
+      const { reason, instruction } = extractErrorMessageFromFetchError(
+        fetchError
+      );
+      setError({ reason, instruction });
     } else if (columns.length <= 0) {
       setError({
         reason: "Display columns is not configured",

--- a/src/components/organisms/SearchConfigEditModal.tsx
+++ b/src/components/organisms/SearchConfigEditModal.tsx
@@ -1,11 +1,7 @@
 import Dialog from "@material-ui/core/Dialog";
 import { useState, useEffect } from "react";
 import LoadingButton from "@material-ui/lab/LoadingButton";
-import {
-  useGetConfig,
-  fetchMetaStore,
-  extractReasonFromFetchError,
-} from "utils";
+import { useGetConfig, fetchMetaStore } from "utils";
 import { useAuth0 } from "@auth0/auth0-react";
 import {
   ErrorMessage,
@@ -21,6 +17,7 @@ import {
   NoticeableLetters,
   LoadingIndicator,
   ErrorMessageProps,
+  extractErrorMessageFromFetchError,
 } from "@dataware-tools/app-common";
 import { produce } from "immer";
 
@@ -133,10 +130,10 @@ const Container = ({
   const fetchError = getConfigError;
   useEffect(() => {
     if (fetchError) {
-      setError({
-        reason: extractReasonFromFetchError(fetchError),
-        instruction: "Please reload this page",
-      });
+      const { reason, instruction } = extractErrorMessageFromFetchError(
+        fetchError
+      );
+      setError({ reason, instruction });
     }
   }, [fetchError]);
 
@@ -177,10 +174,10 @@ const Container = ({
       );
 
       if (updateConfigError) {
-        setError({
-          reason: extractReasonFromFetchError(updateConfigError),
-          instruction: "Please reload this page",
-        });
+        const { reason, instruction } = extractErrorMessageFromFetchError(
+          updateConfigError
+        );
+        setError({ reason, instruction });
         return;
       } else {
         getConfigMutate(updateConfigRes);

--- a/src/components/organisms/SecretConfigEditModal.tsx
+++ b/src/components/organisms/SecretConfigEditModal.tsx
@@ -1,11 +1,7 @@
 import Dialog from "@material-ui/core/Dialog";
 import { useState, useEffect } from "react";
 import LoadingButton from "@material-ui/lab/LoadingButton";
-import {
-  useGetConfig,
-  fetchMetaStore,
-  extractReasonFromFetchError,
-} from "utils";
+import { useGetConfig, fetchMetaStore } from "utils";
 import { useAuth0 } from "@auth0/auth0-react";
 import {
   ErrorMessage,
@@ -21,6 +17,7 @@ import {
   usePrevious,
   NoticeableLetters,
   LoadingIndicator,
+  extractErrorMessageFromFetchError,
 } from "@dataware-tools/app-common";
 import { produce } from "immer";
 
@@ -132,10 +129,10 @@ const Container = ({
   const fetchError = getConfigError;
   useEffect(() => {
     if (fetchError) {
-      setError({
-        reason: extractReasonFromFetchError(fetchError),
-        instruction: "Please reload this page",
-      });
+      const { reason, instruction } = extractErrorMessageFromFetchError(
+        fetchError
+      );
+      setError({ reason, instruction });
     }
   }, [fetchError]);
 
@@ -176,10 +173,10 @@ const Container = ({
       );
 
       if (error) {
-        setError({
-          reason: extractReasonFromFetchError(error),
-          instruction: "Please reload this page",
-        });
+        const { reason, instruction } = extractErrorMessageFromFetchError(
+          error
+        );
+        setError({ reason, instruction });
       } else {
         getConfigMutate(data);
       }

--- a/src/components/pages/DatabasesPage.tsx
+++ b/src/components/pages/DatabasesPage.tsx
@@ -13,6 +13,7 @@ import {
   ErrorMessageProps,
   SearchFormProps,
   PerPageSelectProps,
+  extractErrorMessageFromFetchError,
 } from "@dataware-tools/app-common";
 import { useAuth0 } from "@auth0/auth0-react";
 import { DatabaseList } from "components/organisms/DatabaseList";
@@ -156,10 +157,7 @@ const Container = (): JSX.Element => {
   };
 
   const error: Props["error"] = listDatabasesError
-    ? {
-        reason: JSON.stringify(listDatabasesError),
-        instruction: "Please reload this page",
-      }
+    ? extractErrorMessageFromFetchError(listDatabasesError)
     : undefined;
   const isFetchComplete = Boolean(!error && listDatabasesRes);
   const totalPage = listDatabasesRes?.number_of_pages || 0;

--- a/src/components/pages/RecordsPage.tsx
+++ b/src/components/pages/RecordsPage.tsx
@@ -14,6 +14,7 @@ import {
   SearchFormProps,
   PerPageSelectProps,
   deleteQueryString,
+  extractErrorMessageFromFetchError,
 } from "@dataware-tools/app-common";
 
 import { useAuth0 } from "@auth0/auth0-react";
@@ -32,7 +33,6 @@ import {
   useGetConfig,
   useListPermittedActions,
   UserActionType,
-  extractReasonFromFetchError,
   useGetDatabase,
 } from "utils";
 import { useRecoilState, useSetRecoilState } from "recoil";
@@ -229,10 +229,10 @@ const Page = (): JSX.Element => {
     listRecordsError || getConfigError || listPermittedActionError;
   useEffect(() => {
     if (fetchError) {
-      setError({
-        reason: extractReasonFromFetchError(fetchError),
-        instruction: "Please reload this page",
-      });
+      const { reason, instruction } = extractErrorMessageFromFetchError(
+        fetchError
+      );
+      setError({ reason, instruction });
     } else {
       setError(undefined);
     }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -97,18 +97,6 @@ const compInputFields = (
   }
 };
 
-const extractReasonFromFetchError = (fetchError: {
-  body?: { detail?: unknown };
-}): string => {
-  if (typeof fetchError.body?.detail === "string") {
-    return fetchError.body?.detail;
-  } else if (fetchError.body?.detail) {
-    return JSON.stringify(fetchError.body.detail);
-  } else {
-    return JSON.stringify(fetchError);
-  }
-};
-
 const createSystemMetadata = (
   type: "add" | "update",
   user: { sub: string }
@@ -217,7 +205,6 @@ export {
   compInputFields,
   editableColumnDtype,
   isEditableColumnName,
-  extractReasonFromFetchError,
   createSystemMetadata,
   initializeDatabaseConfig,
   leftFillNum,


### PR DESCRIPTION
## What?
- Show easy understood message when [server error responses](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#server_error_responses) is returned
- Stop showing "Please reload this page" when fetch error occur

## Why?
- To improve usability 
- The message have no mean, and sometimes lead misunderstanding

## See also
- Related https://github.com/dataware-tools/dataware-tools/issues/63
- Depends on https://github.com/dataware-tools/app-common/pull/85

## Screenshot or video
![image](https://user-images.githubusercontent.com/72174933/128283518-4c089aff-0681-42c7-8e17-9e0316814340.png)
