### PR TITLE
Apply delete mode for confirm modal on deleting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1399,9 +1399,9 @@
       }
     },
     "@dataware-tools/app-common": {
-      "version": "21.7.7",
-      "resolved": "https://npm.pkg.github.com/download/@dataware-tools/app-common/21.7.7/4c8b19997595ce691d0ff6c607290b1517dc0194b933c1edb8ff2a341bfa6420",
-      "integrity": "sha512-Rm2/O7nZo1ZHaG3Ht9cvGnvLnK/CRKDCzp/apw8rUK+2uvwNYe/jkSIltDauA75tiw3m5TrAm+TCXJT4c5CjWw=="
+      "version": "21.8.4",
+      "resolved": "https://npm.pkg.github.com/download/@dataware-tools/app-common/21.8.4/8a1e34e1c41cd0453b2c031b759688b6a546ed0f7b55311433bb21804759c44e",
+      "integrity": "sha512-Rg1zobF00XAUZvo20v6VmDmnU8aFlumpGrlhij9CaKXO7Kdvez5jgbZ1x1uEUa481UTiI6RF/pMBGAuZBRXaHg=="
     },
     "@date-io/core": {
       "version": "2.10.7",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@auth0/auth0-react": "^1.4.0",
-    "@dataware-tools/app-common": "^21.7.7",
+    "@dataware-tools/app-common": "^21.8.4",
     "@emotion/react": "^11.1.5",
     "@emotion/styled": "^11.1.5",
     "@material-ui/core": "^5.0.0-alpha.30",

--- a/src/components/organisms/DatabaseList.tsx
+++ b/src/components/organisms/DatabaseList.tsx
@@ -88,7 +88,10 @@ const Container = ({ page, perPage, search }: ContainerProps): JSX.Element => {
   const onDeleteDatabase = async (data: GridCellParams) => {
     if (listDatabasesRes) {
       if (
-        !(await confirm({ title: "Are you sure you want to delete database?" }))
+        !(await confirm({
+          title: "Are you sure you want to delete database?",
+          confirmMode: "delete",
+        }))
       ) {
         return;
       }

--- a/src/components/organisms/FileList.tsx
+++ b/src/components/organisms/FileList.tsx
@@ -129,6 +129,7 @@ const Container = ({ databaseId, recordId }: ContainerProps): JSX.Element => {
     if (
       !(await confirm({
         title: "Are you sure you want to delete file?",
+        confirmMode: "delete",
       }))
     )
       return;

--- a/src/components/organisms/RecordList.tsx
+++ b/src/components/organisms/RecordList.tsx
@@ -120,7 +120,10 @@ const Container = ({
   const onDeleteRecord = async (record: GridCellParams) => {
     if (listRecordsRes) {
       if (
-        !(await confirm({ title: "Are you sure you want to delete record?" }))
+        !(await confirm({
+          title: "Are you sure you want to delete record?",
+          confirmMode: "delete",
+        }))
       ) {
         return;
       }


### PR DESCRIPTION
## What?

app-common をアップデートし各種削除時の確認モーダルで削除用のスタイルを設定

- データベース削除
- レコード削除
- ファイル削除

## Why?

削除確認モーダルのスタイルをわかりやすくしたい

## See also [Optional]

- Issue: https://github.com/dataware-tools/dataware-tools/issues/27
- app-common PR: https://github.com/dataware-tools/app-common/pull/86

## Screenshot or video [Optional]

<img width="861" alt="スクリーンショット 2021-08-13 16 00 04" src="https://user-images.githubusercontent.com/13210107/129317835-2860e698-b6ef-439a-bfd3-c2cea4ec7c5f.png">
<img width="843" alt="スクリーンショット 2021-08-13 16 00 12" src="https://user-images.githubusercontent.com/13210107/129317845-7bfafd1d-5627-44ec-9be9-34147e6e903e.png">
<img width="709" alt="スクリーンショット 2021-08-13 16 00 21" src="https://user-images.githubusercontent.com/13210107/129317847-17a7c849-1d89-4e96-a70a-2224f2206915.png">
