### PR TITLE
Fix bug that incorrect error is shown in configuring input columns

### DIFF
--- a/src/components/organisms/InputConfigList.tsx
+++ b/src/components/organisms/InputConfigList.tsx
@@ -160,13 +160,17 @@ export const InputConfigList = ({
     );
     setRestColumns((prev) => {
       if (prev) {
-        const newOptions = produce(prev, (prev) => {
-          prev.splice(
-            prev.findIndex((elem) => elem.name === newColumn.name),
-            1
-          );
-        });
-        return newOptions;
+        const splicedIndex = prev.findIndex(
+          (elem) => elem.name === newColumn.name
+        );
+        if (splicedIndex >= 0) {
+          const newOptions = produce(prev, (prev) => {
+            prev.splice(splicedIndex, 1);
+          });
+          return newOptions;
+        } else {
+          return prev;
+        }
       } else {
         return prev;
       }
@@ -239,7 +243,11 @@ export const InputConfigList = ({
       .sort(compInputFields) || [];
 
   const alreadyUsedColumnDisplayNames = [
-    ...new Set(value.map((column) => column.display_name)),
+    ...new Set(
+      inputConfig
+        .concat(value.filter((elem) => pydtkSystemColumns.includes(elem.name)))
+        .map((column) => column.display_name)
+    ),
   ];
 
   const alreadyUsedColumnNames = [


### PR DESCRIPTION
## What?
Fix bug that incorrect error is shown in configuring input columns

## Why?
Bug fixes

## Screenshot or video
↓ みたく，設定画面から消したはずの display_name が再利用できないのを修正
![IncorrectOptionBug1](https://user-images.githubusercontent.com/72174933/137293775-4172ca5c-a15b-4d6b-ab80-5c6fef764e81.gif)


