### PR TITLE
Fix bugs that pagination parameter remain when moving between databases

### DIFF
--- a/src/components/pages/RecordsPage.tsx
+++ b/src/components/pages/RecordsPage.tsx
@@ -237,17 +237,6 @@ export const RecordsPage = (): JSX.Element => {
   }, [fetchError]);
 
   useEffect(() => {
-    addQueryString(
-      {
-        page,
-        perPage,
-        search,
-      },
-      "replace"
-    );
-  }, [page, perPage, search]);
-
-  useEffect(() => {
     setRecordPaginateState((prev) => ({
       ...prev,
       page: Number(getQueryString("page")) || 1,
@@ -258,6 +247,17 @@ export const RecordsPage = (): JSX.Element => {
         .map((column) => column.name) || ["record_id"],
     }));
   }, [getConfigRes, setRecordPaginateState, databaseId]);
+
+  useEffect(() => {
+    addQueryString(
+      {
+        page,
+        perPage,
+        search,
+      },
+      "replace"
+    );
+  }, [page, perPage, search]);
 
   useEffect(() => {
     if (listPermittedActionRes) {


### PR DESCRIPTION
## What?
Fix bugs that pagination parameter remain when moving between databases

## Why?
Bug fix

## Screenshot or video
↓ がバグの様子
![PageRemainBug](https://user-images.githubusercontent.com/72174933/137860659-e4fbba81-bce6-4cfa-92ea-adc438abb03f.gif)