### PR TITLE
Support for job-type `ros-provider-with-pydtk`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@auth0/auth0-react": "^1.8.0",
         "@dataware-tools/api-file-provider-client": "^1.6.2",
-        "@dataware-tools/api-job-store-client": "^1.2.1",
+        "@dataware-tools/api-job-store-client": "^1.3.0",
         "@dataware-tools/api-meta-store-client": "^0.5.1",
         "@dataware-tools/api-permission-manager-client": "^0.2.1",
         "@dataware-tools/app-common": "^21.11.3",
@@ -2053,9 +2053,9 @@
       }
     },
     "node_modules/@dataware-tools/api-job-store-client": {
-      "version": "1.2.1",
-      "resolved": "https://npm.pkg.github.com/download/@dataware-tools/api-job-store-client/1.2.1/986659c1e893e7a308b8c30a4f2d26541fc9e923097d0db7721a60ff9022eef4",
-      "integrity": "sha512-mGQTwY2/UfAgbo/BTrpx9XID3Bes6JFi9g98sFRCxyzOtR2m8fTLKIQC/rgsi20a1xQ4ae7w41poRjpmBfVP+g==",
+      "version": "1.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@dataware-tools/api-job-store-client/1.3.0/7e463befca9bbcade6299ea4c703adbcff2b4c6ecc50a6388f0d8bf8c6bdb7b0",
+      "integrity": "sha512-6akK43H5lf9Hp43rmXuijh4k3JP1USXwJCsZkd9KMYXrFwbg173X71A9Qz1ZH/Abixo58rdOkzM+kKe+6ly1aw==",
       "dependencies": {
         "form-data": "^4.0.0",
         "node-fetch": "^2.6.5"
@@ -36191,9 +36191,9 @@
       }
     },
     "@dataware-tools/api-job-store-client": {
-      "version": "1.2.1",
-      "resolved": "https://npm.pkg.github.com/download/@dataware-tools/api-job-store-client/1.2.1/986659c1e893e7a308b8c30a4f2d26541fc9e923097d0db7721a60ff9022eef4",
-      "integrity": "sha512-mGQTwY2/UfAgbo/BTrpx9XID3Bes6JFi9g98sFRCxyzOtR2m8fTLKIQC/rgsi20a1xQ4ae7w41poRjpmBfVP+g==",
+      "version": "1.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@dataware-tools/api-job-store-client/1.3.0/7e463befca9bbcade6299ea4c703adbcff2b4c6ecc50a6388f0d8bf8c6bdb7b0",
+      "integrity": "sha512-6akK43H5lf9Hp43rmXuijh4k3JP1USXwJCsZkd9KMYXrFwbg173X71A9Qz1ZH/Abixo58rdOkzM+kKe+6ly1aw==",
       "requires": {
         "form-data": "^4.0.0",
         "node-fetch": "^2.6.5"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@auth0/auth0-react": "^1.8.0",
     "@dataware-tools/api-file-provider-client": "^1.6.2",
-    "@dataware-tools/api-job-store-client": "^1.2.1",
+    "@dataware-tools/api-job-store-client": "^1.3.0",
     "@dataware-tools/api-meta-store-client": "^0.5.1",
     "@dataware-tools/api-permission-manager-client": "^0.2.1",
     "@dataware-tools/app-common": "^21.11.3",

--- a/src/components/molecules/FilePreviewer/RosbagPreviewer/JobTemplateInfo.tsx
+++ b/src/components/molecules/FilePreviewer/RosbagPreviewer/JobTemplateInfo.tsx
@@ -25,7 +25,7 @@ export const JobTemplateInfo = ({
             <TableCell>Args: </TableCell>
             <TableCell>
               {jobType.job_type.args.map((arg: any) => {
-                return arg.name;
+                return arg.name + " ";
               })}
             </TableCell>
           </TableRow>

--- a/src/components/molecules/FilePreviewer/RosbagPreviewer/index.tsx
+++ b/src/components/molecules/FilePreviewer/RosbagPreviewer/index.tsx
@@ -34,7 +34,12 @@ type Props = {
   job?: jobStore.JobPostedModel;
 };
 
-export type RosbagPreviewerProps = { filePath: string; url: string };
+export type RosbagPreviewerProps = {
+  databaseId: string;
+  recordId: string;
+  filePath: string;
+  url: string;
+};
 const RosbagPreviewerPresentation = ({
   tabIndex,
   handleChangeTab,
@@ -94,6 +99,8 @@ const RosbagPreviewerPresentation = ({
 };
 
 export const RosbagPreviewer = ({
+  databaseId,
+  recordId,
   filePath,
   url,
 }: RosbagPreviewerProps): JSX.Element => {
@@ -141,6 +148,8 @@ export const RosbagPreviewer = ({
       {
         requestBody: {
           job_template_id: parseInt(getJobTemplateRes.job_template_id),
+          database_id: databaseId,
+          record_id: recordId,
           path_to_rosbag: filePath, // FIXME: Generalize JobPostModel
         },
       }

--- a/src/components/molecules/FilePreviewer/index.tsx
+++ b/src/components/molecules/FilePreviewer/index.tsx
@@ -18,13 +18,13 @@ type FilePreviewerContentWithSpec = {
     extensions: string[];
     contentTypes: string[];
   };
-  render: (databaseId: string, file: FileType) => JSX.Element;
+  render: (databaseId: string, recordId: string, file: FileType) => JSX.Element;
 };
 
 const filePreviewerCandidates: Record<string, FilePreviewerContentWithSpec> = {
   default: {
     spec: { extensions: [".*"], contentTypes: [".*"] },
-    render: (databaseId, file) => (
+    render: (databaseId, _, file) => (
       <FileDownloadUrlInjector
         databaseId={databaseId}
         file={file}
@@ -34,7 +34,7 @@ const filePreviewerCandidates: Record<string, FilePreviewerContentWithSpec> = {
   },
   text: {
     spec: { extensions: [".txt"], contentTypes: ["text/.*"] },
-    render: (databaseId, file) => (
+    render: (databaseId, _, file) => (
       <FileDownloadUrlInjector
         databaseId={databaseId}
         file={file}
@@ -44,7 +44,7 @@ const filePreviewerCandidates: Record<string, FilePreviewerContentWithSpec> = {
   },
   markdown: {
     spec: { extensions: [".md"], contentTypes: ["text/.*"] },
-    render: (databaseId, file) => (
+    render: (databaseId, _, file) => (
       <FileDownloadUrlInjector
         databaseId={databaseId}
         file={file}
@@ -54,7 +54,7 @@ const filePreviewerCandidates: Record<string, FilePreviewerContentWithSpec> = {
   },
   csv: {
     spec: { extensions: [".csv"], contentTypes: ["csv/.*"] },
-    render: (databaseId, file) => (
+    render: (databaseId, _, file) => (
       <FileDownloadUrlInjector
         databaseId={databaseId}
         file={file}
@@ -64,7 +64,7 @@ const filePreviewerCandidates: Record<string, FilePreviewerContentWithSpec> = {
   },
   video: {
     spec: { extensions: [".mp4"], contentTypes: ["video/.*"] },
-    render: (databaseId, file) => (
+    render: (databaseId, _, file) => (
       <FileDownloadUrlInjector
         databaseId={databaseId}
         file={file}
@@ -77,7 +77,7 @@ const filePreviewerCandidates: Record<string, FilePreviewerContentWithSpec> = {
       extensions: sourceCodeExtensions,
       contentTypes: ["text/.*"],
     },
-    render: (databaseId, file) => (
+    render: (databaseId, _, file) => (
       <FileDownloadUrlInjector
         databaseId={databaseId}
         file={file}
@@ -90,7 +90,7 @@ const filePreviewerCandidates: Record<string, FilePreviewerContentWithSpec> = {
       extensions: [".jpg", ".jpeg", ".png", ".gif"],
       contentTypes: ["image/.*"],
     },
-    render: (databaseId, file) => (
+    render: (databaseId, _, file) => (
       <FileDownloadUrlInjector
         databaseId={databaseId}
         file={file}
@@ -100,17 +100,24 @@ const filePreviewerCandidates: Record<string, FilePreviewerContentWithSpec> = {
   },
   rosbag: {
     spec: { extensions: [".bag"], contentTypes: ["application/rosbag"] },
-    render: (databaseId, file) => (
+    render: (databaseId, recordId, file) => (
       <FileDownloadUrlInjector
         databaseId={databaseId}
         file={file}
-        render={(_, url) => <RosbagPreviewer filePath={file.path} url={url} />}
+        render={(_, url) => (
+          <RosbagPreviewer
+            databaseId={databaseId}
+            recordId={recordId}
+            filePath={file.path}
+            url={url}
+          />
+        )}
       />
     ),
   },
   audio: {
     spec: { extensions: [".wav", ".mp3"], contentTypes: ["audio/.*"] },
-    render: (databaseId, file) => (
+    render: (databaseId, _, file) => (
       <FileDownloadUrlInjector
         databaseId={databaseId}
         file={file}
@@ -145,10 +152,15 @@ const isContentTypeSupported = (
     : false;
 };
 
-export type FilePreviewerProps = { databaseId: string; file: FileType };
+export type FilePreviewerProps = {
+  databaseId: string;
+  recordId: string;
+  file: FileType;
+};
 
 export const FilePreviewer = ({
   databaseId,
+  recordId,
   file,
 }: FilePreviewerProps): JSX.Element => {
   const [, previewer] = Object.entries(filePreviewerCandidates).find(
@@ -161,6 +173,6 @@ export const FilePreviewer = ({
   ) || [undefined, undefined];
 
   return previewer
-    ? previewer.render(databaseId, file)
-    : filePreviewerCandidates.default.render(databaseId, file);
+    ? previewer.render(databaseId, recordId, file)
+    : filePreviewerCandidates.default.render(databaseId, recordId, file);
 };

--- a/src/components/molecules/FilePreviewer/index.tsx
+++ b/src/components/molecules/FilePreviewer/index.tsx
@@ -13,18 +13,28 @@ import { TextPreviewer } from "./TextPreviewer";
 import { VideoPreviewer } from "./VideoPreviewer";
 import { FileDownloadUrlInjector } from "components/organisms/FileDownloadUrlInjector";
 
+type FilePreviewerContentRenderSpec = {
+  databaseId: string;
+  recordId: string;
+  file: FileType;
+};
+
 type FilePreviewerContentWithSpec = {
   spec: {
     extensions: string[];
     contentTypes: string[];
   };
-  render: (databaseId: string, recordId: string, file: FileType) => JSX.Element;
+  render: ({
+    databaseId,
+    recordId,
+    file,
+  }: FilePreviewerContentRenderSpec) => JSX.Element;
 };
 
 const filePreviewerCandidates: Record<string, FilePreviewerContentWithSpec> = {
   default: {
     spec: { extensions: [".*"], contentTypes: [".*"] },
-    render: (databaseId, _, file) => (
+    render: ({ databaseId, file }) => (
       <FileDownloadUrlInjector
         databaseId={databaseId}
         file={file}
@@ -34,7 +44,7 @@ const filePreviewerCandidates: Record<string, FilePreviewerContentWithSpec> = {
   },
   text: {
     spec: { extensions: [".txt"], contentTypes: ["text/.*"] },
-    render: (databaseId, _, file) => (
+    render: ({ databaseId, file }) => (
       <FileDownloadUrlInjector
         databaseId={databaseId}
         file={file}
@@ -44,7 +54,7 @@ const filePreviewerCandidates: Record<string, FilePreviewerContentWithSpec> = {
   },
   markdown: {
     spec: { extensions: [".md"], contentTypes: ["text/.*"] },
-    render: (databaseId, _, file) => (
+    render: ({ databaseId, file }) => (
       <FileDownloadUrlInjector
         databaseId={databaseId}
         file={file}
@@ -54,7 +64,7 @@ const filePreviewerCandidates: Record<string, FilePreviewerContentWithSpec> = {
   },
   csv: {
     spec: { extensions: [".csv"], contentTypes: ["csv/.*"] },
-    render: (databaseId, _, file) => (
+    render: ({ databaseId, file }) => (
       <FileDownloadUrlInjector
         databaseId={databaseId}
         file={file}
@@ -64,7 +74,7 @@ const filePreviewerCandidates: Record<string, FilePreviewerContentWithSpec> = {
   },
   video: {
     spec: { extensions: [".mp4"], contentTypes: ["video/.*"] },
-    render: (databaseId, _, file) => (
+    render: ({ databaseId, file }) => (
       <FileDownloadUrlInjector
         databaseId={databaseId}
         file={file}
@@ -77,7 +87,7 @@ const filePreviewerCandidates: Record<string, FilePreviewerContentWithSpec> = {
       extensions: sourceCodeExtensions,
       contentTypes: ["text/.*"],
     },
-    render: (databaseId, _, file) => (
+    render: ({ databaseId, file }) => (
       <FileDownloadUrlInjector
         databaseId={databaseId}
         file={file}
@@ -90,7 +100,7 @@ const filePreviewerCandidates: Record<string, FilePreviewerContentWithSpec> = {
       extensions: [".jpg", ".jpeg", ".png", ".gif"],
       contentTypes: ["image/.*"],
     },
-    render: (databaseId, _, file) => (
+    render: ({ databaseId, file }) => (
       <FileDownloadUrlInjector
         databaseId={databaseId}
         file={file}
@@ -100,7 +110,7 @@ const filePreviewerCandidates: Record<string, FilePreviewerContentWithSpec> = {
   },
   rosbag: {
     spec: { extensions: [".bag"], contentTypes: ["application/rosbag"] },
-    render: (databaseId, recordId, file) => (
+    render: ({ databaseId, recordId, file }) => (
       <FileDownloadUrlInjector
         databaseId={databaseId}
         file={file}
@@ -117,7 +127,7 @@ const filePreviewerCandidates: Record<string, FilePreviewerContentWithSpec> = {
   },
   audio: {
     spec: { extensions: [".wav", ".mp3"], contentTypes: ["audio/.*"] },
-    render: (databaseId, _, file) => (
+    render: ({ databaseId, file }) => (
       <FileDownloadUrlInjector
         databaseId={databaseId}
         file={file}
@@ -173,6 +183,6 @@ export const FilePreviewer = ({
   ) || [undefined, undefined];
 
   return previewer
-    ? previewer.render(databaseId, recordId, file)
-    : filePreviewerCandidates.default.render(databaseId, recordId, file);
+    ? previewer.render({ databaseId, recordId, file })
+    : filePreviewerCandidates.default.render({ databaseId, recordId, file });
 };

--- a/src/components/organisms/FileList.tsx
+++ b/src/components/organisms/FileList.tsx
@@ -75,6 +75,7 @@ export const FileListPresentation = ({
           {previewingFile ? (
             <FilePreviewModal
               databaseId={databaseId}
+              recordId={recordId}
               fileList={files}
               open={Boolean(previewingFile)}
               onClose={onCloseFilePreviewModal}

--- a/src/components/organisms/FilePreviewModal.tsx
+++ b/src/components/organisms/FilePreviewModal.tsx
@@ -24,6 +24,7 @@ export type FilePreviewModalPresentationProps = {
 
 export type FilePreviewModalProps = DialogProps & {
   databaseId: string;
+  recordId: string;
   file: FileType;
   fileList: FileType[];
   height?: string;
@@ -31,6 +32,7 @@ export type FilePreviewModalProps = DialogProps & {
 
 export const FilePreviewModalPresentation = ({
   databaseId,
+  recordId,
   file,
   height,
   goPrevFile,
@@ -67,7 +69,11 @@ export const FilePreviewModalPresentation = ({
         <DialogContainer height={height}>
           <DialogBody>
             <DialogMain>
-              <FilePreviewer databaseId={databaseId} file={file} />
+              <FilePreviewer
+                databaseId={databaseId}
+                recordId={recordId}
+                file={file}
+              />
             </DialogMain>
           </DialogBody>
         </DialogContainer>
@@ -78,6 +84,7 @@ export const FilePreviewModalPresentation = ({
 
 export const FilePreviewModal = ({
   databaseId,
+  recordId,
   fileList,
   open,
   file: initFile,
@@ -122,6 +129,7 @@ export const FilePreviewModal = ({
     <FilePreviewModalPresentation
       open={open}
       databaseId={databaseId}
+      recordId={recordId}
       file={currentFile}
       fileNames={fileNames}
       goNextFile={goNextFile}


### PR DESCRIPTION
## What?
Support for job-type `ros-provider-with-pydtk`

## Why?
To use app-scene-viewer

## See also [Optional]
https://github.com/dataware-tools/api-job-store/pull/26
https://github.com/dataware-tools/protocols/pull/52

## Screenshot or video [Optional]

https://user-images.githubusercontent.com/24401842/145756976-be0fce9c-be0c-4e56-a170-9fcf7f71be69.mov


