### PR TITLE
Support for api-job-store with database-id

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@auth0/auth0-react": "^1.8.0",
     "@dataware-tools/api-file-provider-client": "^1.6.2",
-    "@dataware-tools/api-job-store-client": "^1.3.0",
+    "@dataware-tools/api-job-store-client": "^1.4.0",
     "@dataware-tools/api-meta-store-client": "^0.5.1",
     "@dataware-tools/api-permission-manager-client": "^0.2.1",
     "@dataware-tools/app-common": "^21.11.3",

--- a/src/components/molecules/FilePreviewer/RosbagPreviewer/JobSubmitter.tsx
+++ b/src/components/molecules/FilePreviewer/RosbagPreviewer/JobSubmitter.tsx
@@ -1,45 +1,119 @@
+import { useAuth0 } from "@auth0/auth0-react";
 import { jobStore } from "@dataware-tools/api-job-store-client";
+import {
+  ErrorMessage,
+  ErrorMessageProps,
+  extractErrorMessageFromFetchError,
+} from "@dataware-tools/app-common";
 import Button from "@mui/material/Button";
+import { useEffect, useState } from "react";
 import { JobTemplateInfo } from "./JobTemplateInfo";
+import { JobViewer } from "./JobViewer";
 import { SoloSelect } from "components/molecules/SoloSelect";
+import {
+  fetchJobStore,
+  useGetJobTemplate,
+  useGetJobTypes,
+  useListJobTemplate,
+} from "utils";
 
 type JobSubmitterProps = {
-  jobTemplateId?: string;
-  jobTemplateList: jobStore.JobTemplatesModel["job_templates"];
-  jobTemplate?: jobStore.JobTemplateModel;
-  jobType?: jobStore.JobTypeModel;
-  job?: jobStore.JobPostedModel;
-  onSubmitJob: () => void;
-  onChangeJobTemplate: (newValue: string) => void;
+  databaseId: string;
+  recordId: string;
+  filePath: string;
 };
 
 export const JobSubmitter = ({
-  jobTemplateId,
-  jobTemplateList,
-  jobTemplate,
-  jobType,
-  job,
-  onSubmitJob,
-  onChangeJobTemplate,
+  databaseId,
+  recordId,
+  filePath,
 }: JobSubmitterProps): JSX.Element => {
-  return (
+  const { getAccessTokenSilently: getAccessToken } = useAuth0();
+  const [error, setError] = useState<ErrorMessageProps | undefined>(undefined);
+  const [jobTemplateId, setJobTemplateId] = useState<string | undefined>("");
+  const [job, setJob] = useState<jobStore.JobPostedModel | undefined>(
+    undefined
+  );
+  const { data: listJobTemplateRes, error: listJobTemplateError } =
+    useListJobTemplate(getAccessToken, { databaseId });
+  const { data: getJobTemplateRes, error: getJobTemplateError } =
+    useGetJobTemplate(getAccessToken, {
+      jobTemplateId: jobTemplateId ? parseInt(jobTemplateId, 10) : undefined,
+      databaseId: databaseId,
+    });
+  const { data: getJobTypeRes, error: getJobTypeError } = useGetJobTypes(
+    getAccessToken,
+    {
+      jobTypeUid: getJobTemplateRes?.job_template.job_type_uid,
+      databaseId: databaseId,
+    }
+  );
+
+  const fetchError =
+    listJobTemplateError || getJobTemplateError || getJobTypeError;
+  useEffect(() => {
+    if (fetchError) {
+      const { reason, instruction } =
+        extractErrorMessageFromFetchError(fetchError);
+      setError({ reason, instruction });
+    } else {
+      setError(undefined);
+    }
+  }, [fetchError]);
+
+  const onSubmitJob = async () => {
+    if (!getJobTemplateRes) {
+      return;
+    }
+    const [data, error] = await fetchJobStore(
+      getAccessToken,
+      jobStore.JobService.createJob,
+      {
+        databaseId: databaseId,
+        requestBody: {
+          job_template_id: parseInt(getJobTemplateRes.job_template_id),
+          database_id: databaseId,
+          record_id: recordId,
+          path_to_rosbag: filePath, // FIXME: Generalize JobPostModel
+        },
+      }
+    );
+    if (error) {
+      const { reason, instruction } = extractErrorMessageFromFetchError(error);
+      setError({ reason, instruction });
+    } else {
+      setJob(data);
+    }
+  };
+
+  return error ? (
+    <ErrorMessage {...error} />
+  ) : (
     <div>
       <SoloSelect
         label="Select job template"
         value={jobTemplateId}
-        onChange={onChangeJobTemplate}
-        options={jobTemplateList.map((jt) => {
-          return { label: jt.name, value: jt.id };
-        })}
+        onChange={setJobTemplateId}
+        options={
+          listJobTemplateRes
+            ? listJobTemplateRes.job_templates.map((jt) => {
+                return { label: jt.name, value: jt.id };
+              })
+            : []
+        }
       />
-      {jobType && jobTemplate ? (
-        <JobTemplateInfo jobTemplate={jobTemplate} jobType={jobType} />
+      {getJobTypeRes && getJobTemplateRes ? (
+        <JobTemplateInfo
+          jobTemplate={getJobTemplateRes}
+          jobType={getJobTypeRes}
+        />
       ) : null}
-      {jobTemplate && !job ? (
+      {getJobTemplateRes && !job ? (
         <Button onClick={() => onSubmitJob()} disabled={Boolean()}>
           Submit
         </Button>
       ) : null}
+      {getJobTypeRes && job && <JobViewer jobType={getJobTypeRes} job={job} />}
     </div>
   );
 };

--- a/src/components/molecules/FilePreviewer/RosbagPreviewer/JobViewer.tsx
+++ b/src/components/molecules/FilePreviewer/RosbagPreviewer/JobViewer.tsx
@@ -91,12 +91,11 @@ export const JobViewer = ({ job, jobType }: JobViewerProps): JSX.Element => {
     setCurrentShownScript(undefined);
   };
 
-  const onClickExecuteButton: JobViewerPresentationProps["onClickExecuteButton"] = (
-    script
-  ) => {
-    // eslint-disable-next-line no-eval
-    eval(script);
-  };
+  const onClickExecuteButton: JobViewerPresentationProps["onClickExecuteButton"] =
+    (script) => {
+      // eslint-disable-next-line no-eval
+      eval(script);
+    };
 
   const scripts = Object.entries(jobType.job_type.scheme.output)
     // @ts-expect-error I don't know how to resolve this error

--- a/src/utils/fetchClients.tsx
+++ b/src/utils/fetchClients.tsx
@@ -118,9 +118,11 @@ const useListPermittedActions: UseAPI<
     ? async () => {
         permissionManager.OpenAPI.TOKEN = token;
         permissionManager.OpenAPI.BASE = API_ROUTE.PERMISSION.BASE;
-        const res = await permissionManager.PermittedActionService.listPermittedActions(
-          { databaseId, ...query }
-        );
+        const res =
+          await permissionManager.PermittedActionService.listPermittedActions({
+            databaseId,
+            ...query,
+          });
         return res;
       }
     : null;
@@ -291,32 +293,38 @@ const useGetFile: UseAPI<typeof metaStore.FileService.getFile> = (
 
 const useListJobTemplate: UseAPI<
   typeof jobStore.JobTemplateService.listJobTemplates
-> = (token, _nonParam, shouldFetch = true) => {
-  const cacheKey = `${API_ROUTE.JOB.BASE}/job-templates`;
-  const fetcher = async () => {
-    jobStore.OpenAPI.TOKEN = token;
-    jobStore.OpenAPI.BASE = API_ROUTE.JOB.BASE;
-    const res = await jobStore.JobTemplateService.listJobTemplates();
-    return res;
-  };
+> = (token, { databaseId }, shouldFetch = true) => {
+  const cacheKey = `${API_ROUTE.JOB.BASE}/databases/${databaseId}/job-templates`;
+  const fetcher = databaseId
+    ? async () => {
+        jobStore.OpenAPI.TOKEN = token;
+        jobStore.OpenAPI.BASE = API_ROUTE.JOB.BASE;
+        const res = await jobStore.JobTemplateService.listJobTemplates({
+          databaseId: databaseId,
+        });
+        return res;
+      }
+    : null;
   const swrRes = useSWR(shouldFetch ? cacheKey : null, fetcher);
   return { ...swrRes, cacheKey };
 };
 
 const useGetJobTemplate: UseAPI<
   typeof jobStore.JobTemplateService.getJobTemplate
-> = (token, { jobTemplateId }, shouldFetch = true) => {
-  const cacheKey = `${API_ROUTE.JOB.BASE}/job-templates/${jobTemplateId}`;
-  const fetcher = jobTemplateId
-    ? async () => {
-        jobStore.OpenAPI.TOKEN = token;
-        jobStore.OpenAPI.BASE = API_ROUTE.JOB.BASE;
-        const res = await jobStore.JobTemplateService.getJobTemplate({
-          jobTemplateId,
-        });
-        return res;
-      }
-    : null;
+> = (token, { jobTemplateId, databaseId }, shouldFetch = true) => {
+  const cacheKey = `${API_ROUTE.JOB.BASE}/databases/${databaseId}/job-templates/${jobTemplateId}`;
+  const fetcher =
+    jobTemplateId && databaseId
+      ? async () => {
+          jobStore.OpenAPI.TOKEN = token;
+          jobStore.OpenAPI.BASE = API_ROUTE.JOB.BASE;
+          const res = await jobStore.JobTemplateService.getJobTemplate({
+            jobTemplateId,
+            databaseId,
+          });
+          return res;
+        }
+      : null;
   const swrRes = useSWR(
     shouldFetch && jobTemplateId ? cacheKey : null,
     fetcher
@@ -326,20 +334,22 @@ const useGetJobTemplate: UseAPI<
 
 const useGetJobTypes: UseAPI<typeof jobStore.JobTypeService.getJobTypes> = (
   token,
-  { jobTypeUid },
+  { jobTypeUid, databaseId },
   shouldFetch = true
 ) => {
-  const cacheKey = `${API_ROUTE.JOB.BASE}/job-templates/${jobTypeUid}`;
-  const fetcher = jobTypeUid
-    ? async () => {
-        jobStore.OpenAPI.TOKEN = token;
-        jobStore.OpenAPI.BASE = API_ROUTE.JOB.BASE;
-        const res = await jobStore.JobTypeService.getJobTypes({
-          jobTypeUid,
-        });
-        return res;
-      }
-    : null;
+  const cacheKey = `${API_ROUTE.JOB.BASE}/databases/${databaseId}/job-templates/${jobTypeUid}`;
+  const fetcher =
+    jobTypeUid && databaseId
+      ? async () => {
+          jobStore.OpenAPI.TOKEN = token;
+          jobStore.OpenAPI.BASE = API_ROUTE.JOB.BASE;
+          const res = await jobStore.JobTypeService.getJobTypes({
+            jobTypeUid,
+            databaseId,
+          });
+          return res;
+        }
+      : null;
   const swrRes = useSWR(shouldFetch && jobTypeUid ? cacheKey : null, fetcher);
   return { ...swrRes, cacheKey };
 };

--- a/src/utils/utilTypes.ts
+++ b/src/utils/utilTypes.ts
@@ -76,7 +76,14 @@ type UserActionType =
   | "file:read"
   | "file:write"
   | "file:write:add"
-  | "file:write:delete";
+  | "file:write:delete"
+  | "job"
+  | "job:execute"
+  | "job:read"
+  | "job:write"
+  | "job:write:add"
+  | "job:write:update"
+  | "job:write:delete";
 
 type ParamTypeListRecords = Parameters<
   typeof metaStore.RecordService.listRecords


### PR DESCRIPTION
## What?
Support for the latest API-specifications of api-job-store

## Why?
To enable permission check of api-job-store

## See also [Optional]
https://github.com/dataware-tools/protocols/pull/53
https://github.com/dataware-tools/api-job-store/pull/27
https://www.notion.so/humandatawarelab/api-job-store-permission-check-44e6a95bfdde4448b13624c73b79bcbb

## Screenshot or video [Optional]
https://user-images.githubusercontent.com/24401842/146141370-1175bc05-cb9b-49a5-80dc-bd512f1d4208.mov

## TODO
- [x] Wait for PR https://github.com/dataware-tools/api-job-store/pull/27 to be merged
- [x] Release api-job-store v1.4.0
- [x] Re-run CI to make sure that build and test pass