### PR TITLE
Fix "Dependabot can't authenticate to a private package registry" error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,12 @@
 # minimum configuration for two package managers
 
 version: 2
+registries:
+  npm-github:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{secrets.REPO_ACCESS_TOKEN}}
+
 updates:
   # Enable version updates for npm
   - package-ecosystem: "npm"


### PR DESCRIPTION
## What?
Fix "Dependabot can't authenticate to a private package registry" error

## Why?
dependabot にちゃんと動いてほしいので

## See also
[Docs for troubleshooting dependabot error](https://docs.github.com/en/code-security/supply-chain-security/managing-vulnerabilities-in-your-projects-dependencies/troubleshooting-dependabot-errors#dependabot-cant-resolve-or-access-your-dependencies)
[Docs for dependabot config](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#npm-registry)