### PR TITLE
Bug fix on dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
+    registries:
+      - npm-github
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"


### PR DESCRIPTION
## What?
Bug fix on dependabot config

## Why?
```The property '#/registries' includes the "npm-github" registry which is not used in any of the configurations```
と怒られたので