### PR TITLE
Fix build config for symlinking app common

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -31,6 +31,7 @@ module.exports = {
       ...config,
       resolve: {
         ...config.resolve,
+        symlinks: false,
         alias: {
           ...config.resolve.alias,
           "@emotion/core": toPath("node_modules/@emotion/react"),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
     "strict": true,
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
-    "target": "esnext"
+    "target": "esnext",
+    "preserveSymlinks": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,4 +21,20 @@ export default defineConfig({
   cacheDir: "./.vite",
   assetsInclude: ["robots.txt"],
   build: { outDir: "./dist" + packageInfo.basePath },
+  resolve: {
+    preserveSymlinks: true,
+    // this option should be same with app-common peerDependencies
+    dedupe: [
+      "@auth0/auth0-react",
+      "@emotion/react",
+      "@emotion/styled",
+      "@mui/icons-material",
+      "@mui/lab",
+      "@mui/material",
+      "@mui/styles",
+      "oidc-react",
+      "react",
+      "react-dom",
+    ],
+  },
 });


### PR DESCRIPTION
## What?
Fix build config for symlinking app common

## Why?
app-common をシンボリックリンクしたときに，コンポーネントの見た目が違うものになっていて，ヴィジュアルリグレッションテストが正しく行えないから
原因は，app-common の peerDependencies に含まれるライブラリが重複し，MUI の theme が反映されなくなることにあると思われる

## Screenshots or videos
### app-common が npm でインストールされた場合
![image](https://user-images.githubusercontent.com/72174933/146856414-d4fc805c-2d1d-49a3-b7b1-505e377a3d68.png)

### app-common/dist を node_modules/@dataware-tools/app-common にシンボリックリンクした場合
- 修正前
![image](https://user-images.githubusercontent.com/72174933/146856697-7fb9b395-a9a9-4363-b305-870ec98bda55.png)

- 修正後
![image](https://user-images.githubusercontent.com/72174933/146856847-4d4f19b6-e618-4ded-90b7-6e634813e10f.png)
