### PR TITLE
Show menu button even if database have error

### DIFF
--- a/src/pages/RecordsPage.tsx
+++ b/src/pages/RecordsPage.tsx
@@ -108,29 +108,31 @@ export const RecordsPagePresentation = ({
               />
             }
             right={
-              isFetchComplete ? (
-                <>
-                  <SearchForm
-                    onSearch={onChangeSearchText}
-                    defaultValue={searchText}
-                  />
-                  <Spacer direction="horizontal" size="15px" />
-                  <PerPageSelect
-                    perPage={perPage}
-                    setPerPage={onChangePerPage}
-                    values={perPageOptions}
-                  />
-                  <RenderToggleByAction required="metadata:write:add">
-                    <Spacer direction="horizontal" size="15px" />
-                    <RecordAddButton
-                      databaseId={databaseId}
-                      onAddRecordSucceeded={onAddRecordSucceeded}
+              <>
+                {isFetchComplete ? (
+                  <>
+                    <SearchForm
+                      onSearch={onChangeSearchText}
+                      defaultValue={searchText}
                     />
-                  </RenderToggleByAction>
-                  <Spacer direction="horizontal" size="15px" />
-                  <ControlledDatabaseMenuButton databaseId={databaseId} />
-                </>
-              ) : null
+                    <Spacer direction="horizontal" size="15px" />
+                    <PerPageSelect
+                      perPage={perPage}
+                      setPerPage={onChangePerPage}
+                      values={perPageOptions}
+                    />
+                    <RenderToggleByAction required="metadata:write:add">
+                      <Spacer direction="horizontal" size="15px" />
+                      <RecordAddButton
+                        databaseId={databaseId}
+                        onAddRecordSucceeded={onAddRecordSucceeded}
+                      />
+                    </RenderToggleByAction>
+                    <Spacer direction="horizontal" size="15px" />
+                  </>
+                ) : null}
+                <ControlledDatabaseMenuButton databaseId={databaseId} />
+              </>
             }
           />
           <PageMain>


### PR DESCRIPTION
## What?
Show menu button even if database have error

## Why?
Database should be able to be deleted even if it have error

## See also
Resolves https://github.com/dataware-tools/dataware-tools/issues/115

## Screenshot or video
![deleteErrorDatabase](https://user-images.githubusercontent.com/72174933/150479679-a590a84d-7164-4377-95ed-cfbd6649afbd.gif)


