### PR TITLE
Use toast for visualizing error on database add and update

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import "./scrollbar.global.css";
-import { theme } from "@dataware-tools/app-common";
+import { theme, Toaster } from "@dataware-tools/app-common";
 import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeProvider } from "@mui/material/styles";
 import { StylesProvider } from "@mui/styles";
@@ -14,6 +14,7 @@ const App = () => {
       <StylesProvider injectFirst>
         <ThemeProvider theme={theme}>
           <CssBaseline />
+          <Toaster />
           <RecoilRoot>
             <Router />
           </RecoilRoot>

--- a/src/components/organisms/DatabaseEditModal.tsx
+++ b/src/components/organisms/DatabaseEditModal.tsx
@@ -8,8 +8,6 @@ import {
   DialogTitle,
   DialogToolBar,
   DialogWrapper,
-  ErrorMessageProps,
-  ErrorMessage,
   usePrevious,
   confirm,
   useConfirmClosingWindow,
@@ -40,7 +38,6 @@ import {
 export type DatabaseEditModalPresentationProps<T extends boolean> = {
   onSubmit: () => Promise<void>;
   isSubmitting: boolean;
-  error?: ErrorMessageProps;
   formErrors: FieldErrors<FormInput>;
   control: Control<FormInput>;
   onClose: (reason?: string) => void;
@@ -65,7 +62,6 @@ type FormInput = {
 
 export const DatabaseEditModalPresentation = <T extends boolean>({
   onClose,
-  error,
   onSubmit,
   isSubmitting,
   formErrors,
@@ -81,75 +77,69 @@ export const DatabaseEditModalPresentation = <T extends boolean>({
         <DialogContainer padding="0 0 20px">
           <DialogBody>
             <DialogMain>
-              {error ? (
-                <ErrorMessage {...error} />
-              ) : (
-                <>
-                  {add ? (
-                    <Box mt={1}>
-                      <label htmlFor="DatabaseAddModal_database_id">
-                        Database ID
-                      </label>
-                      <Controller
-                        name="database_id"
-                        control={control}
-                        defaultValue=""
-                        rules={{ required: true }}
-                        render={({ field }) => (
-                          <TextField
-                            {...field}
-                            error={formErrors.database_id?.type === "required"}
-                            helperText={
-                              formErrors.database_id?.type === "required" &&
-                              "Database ID is required"
-                            }
-                            fullWidth
-                            id="DatabaseAddModal_database_id"
-                          />
-                        )}
+              {add ? (
+                <Box mt={1}>
+                  <label htmlFor="DatabaseAddModal_database_id">
+                    Database ID
+                  </label>
+                  <Controller
+                    name="database_id"
+                    control={control}
+                    defaultValue=""
+                    rules={{ required: true }}
+                    render={({ field }) => (
+                      <TextField
+                        {...field}
+                        error={formErrors.database_id?.type === "required"}
+                        helperText={
+                          formErrors.database_id?.type === "required" &&
+                          "Database ID is required"
+                        }
+                        fullWidth
+                        id="DatabaseAddModal_database_id"
                       />
-                    </Box>
-                  ) : null}
-                  <Box mt={3}>
-                    <label htmlFor="DatabaseAddModal_name">Name</label>
-                    <Controller
-                      name="name"
-                      control={control}
-                      defaultValue=""
-                      rules={{ required: true }}
-                      render={({ field }) => (
-                        <TextField
-                          {...field}
-                          fullWidth
-                          id="DatabaseAddModal_name"
-                          error={formErrors.name?.type === "required"}
-                          helperText={
-                            formErrors.name?.type === "required" &&
-                            "Name is required"
-                          }
-                        />
-                      )}
+                    )}
+                  />
+                </Box>
+              ) : null}
+              <Box mt={3}>
+                <label htmlFor="DatabaseAddModal_name">Name</label>
+                <Controller
+                  name="name"
+                  control={control}
+                  defaultValue=""
+                  rules={{ required: true }}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      fullWidth
+                      id="DatabaseAddModal_name"
+                      error={formErrors.name?.type === "required"}
+                      helperText={
+                        formErrors.name?.type === "required" &&
+                        "Name is required"
+                      }
                     />
-                  </Box>
-                  <Box mt={3}>
-                    <label htmlFor="DatabaseAddModal_description">
-                      Description
-                    </label>
-                    <Controller
-                      name="description"
-                      control={control}
-                      defaultValue=""
-                      render={({ field }) => (
-                        <TextField
-                          {...field}
-                          fullWidth
-                          id="DatabaseAddModal_description"
-                        />
-                      )}
+                  )}
+                />
+              </Box>
+              <Box mt={3}>
+                <label htmlFor="DatabaseAddModal_description">
+                  Description
+                </label>
+                <Controller
+                  name="description"
+                  control={control}
+                  defaultValue=""
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      fullWidth
+                      id="DatabaseAddModal_description"
                     />
-                  </Box>
-                </>
-              )}
+                  )}
+                />
+              </Box>
             </DialogMain>
           </DialogBody>
         </DialogContainer>
@@ -183,7 +173,6 @@ export const DatabaseEditModal = <T extends boolean>({
     reset,
   } = useForm<FormInput>({ defaultValues: currentData });
   const { page, perPage, search } = useRecoilValue(databasePaginateState);
-  const [error, setError] = useState<ErrorMessageProps | undefined>(undefined);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { data: listDatabasesRes, mutate: listDatabasesMutate } =
@@ -209,7 +198,6 @@ export const DatabaseEditModal = <T extends boolean>({
   });
 
   const initializeState = () => {
-    setError(undefined);
     setIsSubmitting(false);
     reset(currentData);
   };
@@ -355,7 +343,6 @@ export const DatabaseEditModal = <T extends boolean>({
       onClose={onClose}
       onSubmit={handleSubmit(onSubmit)}
       isSubmitting={isSubmitting}
-      error={error}
       formErrors={formErrors}
       control={control}
       {...delegated}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -221,4 +221,5 @@ export {
   getFileName,
 };
 export * from "./fetchClients";
+export * from "./toasts";
 export * from "./utilTypes";

--- a/src/utils/toasts.tsx
+++ b/src/utils/toasts.tsx
@@ -1,0 +1,23 @@
+import {
+  extractErrorMessageFromFetchError,
+  ErrorMessage,
+  ToastHavingDetailInfo,
+} from "@dataware-tools/app-common";
+import { toast } from "react-toastify";
+
+export const enqueueErrorToastForFetchError = (message: string, error: any) => {
+  const { reason, instruction } = extractErrorMessageFromFetchError(error);
+  toast.error(
+    <ToastHavingDetailInfo
+      detailContent={
+        <ErrorMessage
+          variant="transparent"
+          reason={reason}
+          instruction={instruction}
+        />
+      }
+    >
+      {message}
+    </ToastHavingDetailInfo>
+  );
+};


### PR DESCRIPTION
## What?

- app-commonのToasterコンポーネントとToastHavingDetailInfoコンポーネントをエラーのフィードバックとして使うようにした
- ひとまずデータベース追加・更新時に対応

## Why?

ある操作に対する一時的なエラーをトーストに切り替えたい

## See also [Optional]

PR on app-common: https://github.com/dataware-tools/app-common/pull/258

## Screenshot or video [Optional]


https://user-images.githubusercontent.com/13210107/181449193-1e40829f-1227-46b6-8b76-a3bcd829863c.mov

